### PR TITLE
feat: build battle lobby get started flow

### DIFF
--- a/apps/app-ui/src/components/GetStarted/GetStartedFlow.tsx
+++ b/apps/app-ui/src/components/GetStarted/GetStartedFlow.tsx
@@ -1,0 +1,131 @@
+import { Form, Input, Modal, Space, Typography, Button, message, theme } from "antd";
+import type { FC } from "react";
+import { useCallback, useMemo, useState } from "react";
+import type { HeroIconKey } from "../../features/arena/arenaSlice";
+import { IconFactory } from "../common/IconFactory";
+import { HostBattleForm } from "./HostBattleForm";
+import type { HostBattleFormValues } from "./HostBattleForm";
+
+interface GetStartedFlowProps {
+  label: string;
+  icon: HeroIconKey;
+}
+
+const inviteLinkPattern = /^(https?:\/\/\S+|[A-Z0-9-]{6,})$/i;
+
+export const GetStartedFlow: FC<GetStartedFlowProps> = ({ label, icon }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isHosting, setIsHosting] = useState(false);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [joinForm] = Form.useForm<{ inviteLink: string }>();
+  const [hostForm] = Form.useForm<HostBattleFormValues>();
+  const { token } = theme.useToken();
+
+  const helperTextStyle = useMemo(
+    () => ({
+      color: token.colorTextSecondary,
+      fontSize: token.fontSizeSM,
+    }),
+    [token],
+  );
+
+  const closeModal = useCallback(() => {
+    // Reset modal state so each launch starts with a clean slate.
+    setIsModalOpen(false);
+    setIsHosting(false);
+    setShowAdvancedOptions(false);
+    joinForm.resetFields();
+    hostForm.resetFields();
+  }, [hostForm, joinForm]);
+
+  const handleJoin = useCallback(async () => {
+    try {
+      const { inviteLink } = await joinForm.validateFields();
+      // TODO: Integrate with battle join endpoint once available.
+      message.success(`Attempting to join with ${inviteLink}`);
+    } catch (error) {
+      // Ant Design surfaces validation issues inline; no additional handling required here.
+    }
+  }, [joinForm]);
+
+  const handleHostSubmit = useCallback(
+    async (values: HostBattleFormValues) => {
+      // TODO: Replace mock handling with create-battle mutation.
+      message.success(`Battle "${values.battleName}" configured`);
+      closeModal();
+    },
+    [closeModal],
+  );
+
+  const handleHostAction = useCallback(() => {
+    setIsHosting(true);
+    // Ensures advanced options reset whenever the host flow re-opens.
+    setShowAdvancedOptions(false);
+  }, []);
+
+  return (
+    <>
+      <Button
+        type="primary"
+        size="large"
+        icon={<IconFactory icon={icon} />}
+        onClick={() => setIsModalOpen(true)}
+      >
+        {label}
+      </Button>
+      <Modal
+        open={isModalOpen}
+        onCancel={closeModal}
+        footer={null}
+        title="Jump into a battle"
+        width={720}
+        style={{ maxWidth: "90vw" }}
+        destroyOnClose
+      >
+        <Space direction="vertical" size="large" style={{ width: "100%" }}>
+          <Form layout="vertical" form={joinForm}>
+            <Form.Item label="Invite link or code" required style={{ marginBottom: token.marginXS }}>
+              <Space.Compact style={{ width: "100%" }}>
+                <Form.Item
+                  name="inviteLink"
+                  noStyle
+                  rules={[
+                    { required: true, message: "Enter a battle invite link or code." },
+                    {
+                      pattern: inviteLinkPattern,
+                      message: "Use a full URL or a code like BTL-1234.",
+                    },
+                  ]}
+                >
+                  <Input placeholder="https://arena.gg/battle/abc or BTL-1234" allowClear />
+                </Form.Item>
+                <Button type="primary" onClick={handleJoin}>
+                  Join
+                </Button>
+              </Space.Compact>
+            </Form.Item>
+          </Form>
+          <Typography.Text style={helperTextStyle}>
+            Accepts secure https links or invite codes (e.g. BTL-9821, TEAM-01).
+          </Typography.Text>
+          {!isHosting ? (
+            <Button type="default" block onClick={handleHostAction}>
+              Host your own battle
+            </Button>
+          ) : null}
+          {isHosting ? (
+            <>
+              <Typography.Text strong>Configure your battle</Typography.Text>
+              <HostBattleForm
+                form={hostForm}
+                showAdvanced={showAdvancedOptions}
+                onToggleAdvanced={setShowAdvancedOptions}
+                onSubmit={handleHostSubmit}
+              />
+            </>
+          ) : null}
+        </Space>
+      </Modal>
+    </>
+  );
+};

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm.tsx
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm.tsx
@@ -1,0 +1,347 @@
+import { Button, Checkbox, Col, Divider, Form, Input, InputNumber, Radio, Row, Select, Space, Switch, Typography } from "antd";
+import type { FormInstance } from "antd";
+import type { FC } from "react";
+import { useMemo } from "react";
+
+type PrivacySetting = "public" | "invite";
+
+type HostBattleFormValues = {
+  battleName: string;
+  shortDescription?: string;
+  gameMode?: string;
+  difficulty?: string;
+  maxPlayers?: number;
+  privacy: PrivacySetting;
+  allowSpectators: boolean;
+  voiceChat: boolean;
+  autoStart: boolean;
+  turnTimeLimit?: number;
+  totalDuration?: number;
+  scoringRules?: string;
+  tieBreakPreference?: string;
+  powerUps?: string[];
+  teamBalancing: boolean;
+  ratingFloor?: number;
+  ratingCeiling?: number;
+  moderatorRoles?: string[];
+  preloadedResources?: string;
+  rematchDefaults: boolean;
+  joinQueueSize?: number;
+  password?: string;
+  linkExpiry?: string;
+};
+
+interface HostBattleFormProps {
+  form: FormInstance<HostBattleFormValues>;
+  showAdvanced: boolean;
+  onToggleAdvanced: (checked: boolean) => void;
+  onSubmit: (values: HostBattleFormValues) => void;
+}
+
+const basicSelectOptions = {
+  gameModes: [
+    { label: "Head-to-head", value: "head-to-head" },
+    { label: "Team battle", value: "team" },
+    { label: "Battle royale", value: "royale" },
+  ],
+  difficulty: [
+    { label: "Beginner", value: "beginner" },
+    { label: "Intermediate", value: "intermediate" },
+    { label: "Expert", value: "expert" },
+  ],
+};
+
+const advancedSelectOptions = {
+  scoringRules: [
+    { label: "Points per challenge", value: "points-per-challenge" },
+    { label: "Time weighted", value: "time-weighted" },
+    { label: "First-to-finish", value: "first-to-finish" },
+  ],
+  tieBreaks: [
+    { label: "Fastest submission", value: "fastest-submission" },
+    { label: "Highest accuracy", value: "highest-accuracy" },
+    { label: "Rematch", value: "rematch" },
+  ],
+  powerUps: [
+    { label: "Hint reveal", value: "hint" },
+    { label: "Time freeze", value: "time-freeze" },
+    { label: "Double points", value: "double-points" },
+  ],
+  moderatorRoles: [
+    { label: "Judge", value: "judge" },
+    { label: "Streamer", value: "streamer" },
+    { label: "Scorekeeper", value: "scorekeeper" },
+  ],
+  resources: [
+    { label: "Starter template", value: "starter-template" },
+    { label: "Sample data pack", value: "sample-data" },
+    { label: "Benchmark suite", value: "benchmark" },
+  ],
+  linkExpiry: [
+    { label: "Never", value: "never" },
+    { label: "24 hours", value: "24h" },
+    { label: "7 days", value: "7d" },
+    { label: "Custom", value: "custom" },
+  ],
+};
+
+export const HostBattleForm: FC<HostBattleFormProps> = ({
+  form,
+  showAdvanced,
+  onToggleAdvanced,
+  onSubmit,
+}) => {
+  const initialValues = useMemo<Partial<HostBattleFormValues>>(
+    () => ({
+      privacy: "public",
+      allowSpectators: true,
+      voiceChat: false,
+      autoStart: true,
+      teamBalancing: true,
+      rematchDefaults: false,
+    }),
+    [],
+  );
+
+  const fieldColProps = useMemo(
+    () => ({
+      xs: 24,
+      md: 12,
+    }),
+    [],
+  );
+
+  const advancedColProps = useMemo(
+    () => ({
+      xs: 24,
+      md: 12,
+      lg: 8,
+    }),
+    [],
+  );
+
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      initialValues={initialValues}
+      onFinish={onSubmit}
+      requiredMark="optional"
+    >
+      <Typography.Title level={5} style={{ marginBottom: 16 }}>
+        Battle basics
+      </Typography.Title>
+      <Row gutter={[16, 16]}>
+        <Col {...fieldColProps}>
+          <Form.Item
+            name="battleName"
+            label="Battle name"
+            rules={[{ required: true, message: "Give your battle a name." }]}
+          >
+            <Input placeholder="Friday Night Algorithms" allowClear />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="shortDescription" label="Short description">
+            <Input placeholder="Add a quick pitch for players" allowClear />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="gameMode" label="Game mode">
+            <Select
+              placeholder="Select a mode"
+              options={basicSelectOptions.gameModes}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="difficulty" label="Difficulty">
+            <Select
+              placeholder="Select difficulty"
+              options={basicSelectOptions.difficulty}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="maxPlayers" label="Max players">
+            <InputNumber min={2} max={100} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="privacy" label="Privacy">
+            <Radio.Group optionType="button" buttonStyle="solid">
+              <Radio.Button value="public">Public</Radio.Button>
+              <Radio.Button value="invite">Invite only</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item
+            name="allowSpectators"
+            label="Allow spectators"
+            valuePropName="checked"
+          >
+            <Switch />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="voiceChat" label="Voice chat" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </Col>
+        <Col {...fieldColProps}>
+          <Form.Item name="autoStart" label="Auto-start when full" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </Col>
+      </Row>
+
+      <Divider />
+
+      <Checkbox checked={showAdvanced} onChange={(event) => onToggleAdvanced(event.target.checked)}>
+        Show advanced options
+      </Checkbox>
+
+      {showAdvanced ? (
+        <Space direction="vertical" size={24} style={{ width: "100%", marginTop: 16 }}>
+          <Typography.Title level={5} style={{ marginBottom: 0 }}>
+            Advanced settings
+          </Typography.Title>
+          <Row gutter={[16, 16]}>
+            <Col {...advancedColProps}>
+              <Form.Item name="turnTimeLimit" label="Turn time limit (seconds)">
+                <InputNumber min={10} max={600} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="totalDuration" label="Total battle duration (minutes)">
+                <InputNumber min={5} max={240} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="scoringRules" label="Scoring rules">
+                <Select
+                  placeholder="Choose scoring rules"
+                  options={advancedSelectOptions.scoringRules}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="tieBreakPreference" label="Tie-break preference">
+                <Select
+                  placeholder="Choose tie-breaker"
+                  options={advancedSelectOptions.tieBreaks}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="powerUps" label="Power-up pool">
+                <Select
+                  mode="multiple"
+                  placeholder="Select power-ups"
+                  options={advancedSelectOptions.powerUps}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="teamBalancing" label="Team balancing" valuePropName="checked">
+                <Switch />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="ratingFloor" label="Player rating floor">
+                <InputNumber min={0} max={5000} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="ratingCeiling" label="Player rating ceiling">
+                <InputNumber min={0} max={5000} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="moderatorRoles" label="Moderator roles">
+                <Select
+                  mode="multiple"
+                  placeholder="Assign moderators"
+                  options={advancedSelectOptions.moderatorRoles}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="preloadedResources" label="Pre-loaded resources">
+                <Select
+                  placeholder="Select resources"
+                  options={advancedSelectOptions.resources}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="rematchDefaults" label="Rematch defaults" valuePropName="checked">
+                <Switch />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="joinQueueSize" label="Queue size for join requests">
+                <InputNumber min={0} max={200} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item shouldUpdate noStyle>
+                {() => {
+                  const privacy = form.getFieldValue("privacy") as PrivacySetting;
+                  // Keep password disabled until "Invite only" is selected so users understand the dependency.
+                  return (
+                    <Form.Item name="password" label="Password">
+                      <Input.Password
+                        placeholder={privacy === "invite" ? "Share a secure password" : "Invite only required"}
+                        disabled={privacy !== "invite"}
+                        allowClear
+                      />
+                    </Form.Item>
+                  );
+                }}
+              </Form.Item>
+            </Col>
+            <Col {...advancedColProps}>
+              <Form.Item name="linkExpiry" label="Link expiry">
+                <Select
+                  placeholder="Choose expiry"
+                  options={advancedSelectOptions.linkExpiry}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        </Space>
+      ) : null}
+
+      <Form.Item shouldUpdate style={{ marginTop: 32 }}>
+        {() => (
+          <Space style={{ width: "100%", justifyContent: "flex-end" }}>
+            <Button
+              onClick={() => {
+                form.resetFields();
+                // Reset the advanced toggle alongside the form fields for clarity.
+                onToggleAdvanced(false);
+              }}
+            >
+              Reset
+            </Button>
+            <Button type="primary" htmlType="submit">
+              Create battle
+            </Button>
+          </Space>
+        )}
+      </Form.Item>
+    </Form>
+  );
+};
+
+export type { HostBattleFormValues };

--- a/apps/app-ui/src/components/Hero/HeroCopy.tsx
+++ b/apps/app-ui/src/components/Hero/HeroCopy.tsx
@@ -2,7 +2,7 @@ import { Button, Space, Tag, Typography, theme } from "antd";
 import type { FC } from "react";
 import { useMemo } from "react";
 import type { HeroContent } from "../../features/arena/arenaSlice";
-import { IconFactory } from "../common/IconFactory";
+import { GetStartedFlow } from "../GetStarted/GetStartedFlow";
 import { StatChip } from "../common/StatChip";
 
 const { Title, Paragraph } = Typography;
@@ -90,13 +90,10 @@ export const HeroCopy: FC<HeroCopyProps> = ({ hero }) => {
       </Title>
       <Paragraph style={subtitleStyle}>{hero.subtitle}</Paragraph>
       <Space size="large" wrap>
-        <Button
-          type="primary"
-          size="large"
-          icon={<IconFactory icon={hero.actions.primary.icon} />}
-        >
-          {hero.actions.primary.label}
-        </Button>
+        <GetStartedFlow
+          label={hero.actions.primary.label}
+          icon={hero.actions.primary.icon}
+        />
         <Button size="large" ghost>
           {hero.actions.secondary.label}
         </Button>


### PR DESCRIPTION
## Summary
- add a reusable Get Started flow modal with invite link validation and join mock handling
- implement the host battle configuration form with basic and advanced settings that respond to toggles
- wire the hero CTA to the new flow so the lobby experience launches from the landing page

## Testing
- pnpm --filter app-ui build


------
https://chatgpt.com/codex/tasks/task_e_68dd3136631883258e15849284cfd894