### PR TITLE
Integrate frontend auth with backend and add environment switching

### DIFF
--- a/apps/app-backend/src/controllers/authController.ts
+++ b/apps/app-backend/src/controllers/authController.ts
@@ -23,19 +23,17 @@ export const registerHandler: RequestHandler = async (req, res, next) => {
       throw createHttpError(400, 'Invalid registration payload');
     }
 
-    if (!req.file) {
-      throw createHttpError(400, 'Profile photo is required');
-    }
-
     const authResponse = await registerUser({
       username: parsed.data.username,
       firstName: parsed.data.firstName,
       lastName: parsed.data.lastName,
       password: parsed.data.password,
-      photo: {
-        buffer: req.file.buffer,
-        mimetype: req.file.mimetype,
-      },
+      photo: req.file
+        ? {
+            buffer: req.file.buffer,
+            mimetype: req.file.mimetype,
+          }
+        : undefined,
     });
 
     res.status(201).json(authResponse);

--- a/apps/app-backend/src/services/authService.ts
+++ b/apps/app-backend/src/services/authService.ts
@@ -13,7 +13,7 @@ type RegisterInput = {
   firstName: string;
   lastName: string;
   password: string;
-  photo: {
+  photo?: {
     buffer: Buffer;
     mimetype: string;
   };
@@ -29,7 +29,7 @@ export type PublicUser = {
   username: string;
   firstName: string;
   lastName: string;
-  photoPath: string;
+  photoPath: string | null;
   createdAt: string;
 };
 
@@ -47,7 +47,7 @@ const toPublicUser = (user: DbUserRow): PublicUser => ({
   createdAt: user.created_at.toISOString(),
 });
 
-const saveProfilePhoto = async (photo: RegisterInput['photo']): Promise<string> => {
+const saveProfilePhoto = async (photo: NonNullable<RegisterInput['photo']>): Promise<string> => {
   await ensureDirectory(env.uploadsDir);
   const fileId = uuid();
   const extension = photo.mimetype === 'image/png' ? 'png' : 'jpg';
@@ -78,7 +78,7 @@ export const registerUser = async (input: RegisterInput): Promise<AuthResponse> 
   }
 
   const passwordHash = await bcrypt.hash(input.password, 12);
-  const photoPath = await saveProfilePhoto(input.photo);
+  const photoPath = input.photo ? await saveProfilePhoto(input.photo) : null;
   const userId = uuid();
 
   const createdUser = await insertUser({

--- a/apps/app-ui/src/components/auth/AuthModal.tsx
+++ b/apps/app-ui/src/components/auth/AuthModal.tsx
@@ -1,6 +1,9 @@
-import { Alert, Button, Form, Input, Space, Typography } from "antd";
+import { UploadOutlined } from "@ant-design/icons";
+import { Alert, Button, Form, Input, Space, Typography, Upload } from "antd";
 import type { FC } from "react";
 import { useCallback, useEffect } from "react";
+import type { UploadFile } from "antd/es/upload/interface";
+import type { RegisterRequestPayload } from "@rc/api-client";
 import { AppModal } from "../common/AppModal";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import {
@@ -10,7 +13,6 @@ import {
   submitRegistration,
   type AuthUiMode,
   type LoginFormValues,
-  type RegisterFormValues,
 } from "../../features/auth/authSlice";
 import {
   selectAuthError,
@@ -22,6 +24,28 @@ import {
 const titleByMode: Record<AuthUiMode, string> = {
   login: "Welcome back",
   register: "Create your account",
+};
+
+type RegisterFormValues = {
+  username: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  confirmPassword: string;
+  photo?: UploadFile[];
+};
+
+const normalizeUploadValue = (value: unknown): UploadFile[] => {
+  if (Array.isArray(value)) {
+    return value as UploadFile[];
+  }
+
+  if (value && typeof value === "object" && "fileList" in value) {
+    const fileList = (value as { fileList?: UploadFile[] }).fileList ?? [];
+    return fileList.slice(-1);
+  }
+
+  return [];
 };
 
 export const AuthModal: FC = () => {
@@ -54,14 +78,30 @@ export const AuthModal: FC = () => {
 
   const handleLoginFinish = useCallback(
     (values: LoginFormValues) => {
-      void dispatch(submitLogin(values));
+      const payload: LoginFormValues = {
+        username: values.username.trim(),
+        password: values.password,
+      };
+      void dispatch(submitLogin(payload));
     },
     [dispatch],
   );
 
   const handleRegisterFinish = useCallback(
     (values: RegisterFormValues) => {
-      void dispatch(submitRegistration(values));
+      const request: RegisterRequestPayload = {
+        username: values.username.trim(),
+        firstName: values.firstName.trim(),
+        lastName: values.lastName.trim(),
+        password: values.password,
+      };
+
+      const file = values.photo?.[0]?.originFileObj;
+      if (file) {
+        request.photo = file as File;
+      }
+
+      void dispatch(submitRegistration(request));
     },
     [dispatch],
   );
@@ -79,8 +119,8 @@ export const AuthModal: FC = () => {
         <div>
           <Typography.Text type="secondary">
             {mode === "login"
-              ? "Please enter the credentials associated with your account."
-              : "A few quick details and you will be ready to join the action."}
+              ? "Please enter your username and password to continue."
+              : "Share a few quick details to set up your arena profile."}
           </Typography.Text>
         </div>
 
@@ -95,14 +135,15 @@ export const AuthModal: FC = () => {
             requiredMark="optional"
           >
             <Form.Item
-              label="Email"
-              name="email"
+              label="Username"
+              name="username"
               rules={[
-                { required: true, message: "Enter the email you use to sign in." },
-                { type: "email", message: "That does not look like a valid email address." },
+                { required: true, message: "Enter your username." },
+                { min: 3, message: "Usernames need to be at least 3 characters long." },
+                { max: 64, message: "Usernames cannot exceed 64 characters." },
               ]}
             >
-              <Input type="email" placeholder="you@example.com" autoFocus allowClear />
+              <Input placeholder="your_username" autoFocus allowClear autoComplete="username" />
             </Form.Item>
             <Form.Item
               label="Password"
@@ -127,21 +168,29 @@ export const AuthModal: FC = () => {
             requiredMark="optional"
           >
             <Form.Item
-              label="Full name"
-              name="fullName"
-              rules={[{ required: true, message: "Let us know how to address you." }]}
-            >
-              <Input placeholder="Jane Doe" autoFocus allowClear />
-            </Form.Item>
-            <Form.Item
-              label="Email"
-              name="email"
+              label="Username"
+              name="username"
               rules={[
-                { required: true, message: "Enter an email so we can reach you." },
-                { type: "email", message: "That does not look like a valid email address." },
+                { required: true, message: "Choose a username." },
+                { min: 3, message: "Usernames need to be at least 3 characters long." },
+                { max: 64, message: "Usernames cannot exceed 64 characters." },
               ]}
             >
-              <Input type="email" placeholder="you@example.com" allowClear />
+              <Input placeholder="your_username" autoFocus allowClear autoComplete="username" />
+            </Form.Item>
+            <Form.Item
+              label="First name"
+              name="firstName"
+              rules={[{ required: true, message: "Tell us your first name." }, { max: 120, message: "Keep it under 120 characters." }]}
+            >
+              <Input placeholder="Jane" allowClear autoComplete="given-name" />
+            </Form.Item>
+            <Form.Item
+              label="Last name"
+              name="lastName"
+              rules={[{ required: true, message: "What is your last name?" }, { max: 120, message: "Keep it under 120 characters." }]}
+            >
+              <Input placeholder="Doe" allowClear autoComplete="family-name" />
             </Form.Item>
             <Form.Item
               label="Password"
@@ -170,6 +219,22 @@ export const AuthModal: FC = () => {
               ]}
             >
               <Input.Password placeholder="Repeat your password" autoComplete="new-password" />
+            </Form.Item>
+            <Form.Item
+              label="Profile photo"
+              name="photo"
+              valuePropName="fileList"
+              getValueFromEvent={normalizeUploadValue}
+              extra="Optional. Upload a PNG or JPG image (max 5 MB)."
+            >
+              <Upload
+                beforeUpload={() => false}
+                accept="image/png,image/jpeg"
+                maxCount={1}
+                listType="picture"
+              >
+                <Button icon={<UploadOutlined />}>Select image</Button>
+              </Upload>
             </Form.Item>
             <Button type="primary" htmlType="submit" block loading={isSubmitting}>
               Create account

--- a/apps/app-ui/src/components/common/AppNavbar.tsx
+++ b/apps/app-ui/src/components/common/AppNavbar.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { openLoginModal } from "../../features/auth/authSlice";
 import { useAppDispatch } from "../../store/hooks";
+import { EnvironmentSwitcher } from "./EnvironmentSwitcher";
 import { ThemeToggle } from "./ThemeToggle";
 
 const { Header } = Layout;
@@ -60,6 +61,7 @@ export const AppNavbar: FC = () => {
         ) : null}
       </div>
       <Space size="middle" align="center">
+        <EnvironmentSwitcher />
         <Button type="default" onClick={handleLoginClick}>
           Log in
         </Button>

--- a/apps/app-ui/src/components/common/EnvironmentSwitcher.tsx
+++ b/apps/app-ui/src/components/common/EnvironmentSwitcher.tsx
@@ -1,0 +1,38 @@
+import { Select, Space, Typography } from "antd";
+import type { FC } from "react";
+import { apiEnvironmentOptions } from "../../config/api-environments";
+import { setApiEnvironment } from "../../features/environment/environmentSlice";
+import { selectCurrentEnvironmentKey } from "../../features/environment/selectors";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+
+const renderLabel = (label: string, baseUrl?: string) => (
+  <Space direction="vertical" size={0} style={{ width: "100%" }}>
+    <span>{label}</span>
+    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+      {baseUrl ?? "Mock mode"}
+    </Typography.Text>
+  </Space>
+);
+
+export const EnvironmentSwitcher: FC = () => {
+  const dispatch = useAppDispatch();
+  const selected = useAppSelector(selectCurrentEnvironmentKey);
+  const disabled = apiEnvironmentOptions.length <= 1;
+
+  return (
+    <Select
+      size="small"
+      value={selected}
+      onChange={(value) => dispatch(setApiEnvironment(value))}
+      options={apiEnvironmentOptions.map((option) => ({
+        value: option.key,
+        label: renderLabel(option.label, option.baseUrl),
+      }))}
+      style={{ minWidth: 220 }}
+      dropdownMatchSelectWidth={false}
+      optionLabelProp="label"
+      disabled={disabled}
+      aria-label="Select backend environment"
+    />
+  );
+};

--- a/apps/app-ui/src/config/api-environments.ts
+++ b/apps/app-ui/src/config/api-environments.ts
@@ -1,0 +1,119 @@
+export interface ApiEnvironmentOption {
+  key: string;
+  label: string;
+  baseUrl?: string;
+}
+
+const sanitizeBaseUrl = (input?: string | null): string | undefined => {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.replace(/\/$/, "");
+};
+
+const parseConfiguredEnvironments = (): ApiEnvironmentOption[] => {
+  const raw = (import.meta.env?.VITE_API_ENVIRONMENTS as string | undefined)?.trim();
+
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+
+        const key = typeof (entry as { key?: unknown }).key === "string" ? (entry as { key: string }).key.trim() : "";
+        const label =
+          typeof (entry as { label?: unknown }).label === "string" ? (entry as { label: string }).label.trim() : "";
+        const baseUrl = sanitizeBaseUrl((entry as { baseUrl?: unknown }).baseUrl as string | undefined);
+
+        if (!key || !label) {
+          return null;
+        }
+
+        return { key, label, baseUrl } satisfies ApiEnvironmentOption;
+      })
+      .filter((option): option is ApiEnvironmentOption => Boolean(option));
+  } catch (error) {
+    console.warn("Failed to parse VITE_API_ENVIRONMENTS. Falling back to defaults.", error);
+    return [];
+  }
+};
+
+const configuredOptions = parseConfiguredEnvironments();
+const configuredBaseUrl = sanitizeBaseUrl(import.meta.env?.VITE_API_BASE_URL as string | undefined);
+const configuredKey = (import.meta.env?.VITE_API_ENVIRONMENT_KEY as string | undefined)?.trim();
+const configuredLabel = (import.meta.env?.VITE_API_ENVIRONMENT_LABEL as string | undefined)?.trim();
+
+const optionsMap = new Map<string, ApiEnvironmentOption>();
+
+const addOption = (option: ApiEnvironmentOption) => {
+  if (!option.key) {
+    return;
+  }
+
+  optionsMap.set(option.key, option);
+};
+
+configuredOptions.forEach(addOption);
+
+if (configuredBaseUrl) {
+  addOption({
+    key: configuredKey || "configured",
+    label: configuredLabel || "Configured backend",
+    baseUrl: configuredBaseUrl,
+  });
+}
+
+addOption({
+  key: "mock",
+  label: "Mock API (offline)",
+});
+
+export const apiEnvironmentOptions = Array.from(optionsMap.values());
+
+const defaultEnvironmentKey = (import.meta.env?.VITE_API_DEFAULT_ENVIRONMENT as string | undefined)?.trim();
+
+export const API_ENV_STORAGE_KEY = "app-ui-selected-api-environment";
+
+export const findApiEnvironmentOption = (key: string | null | undefined): ApiEnvironmentOption | undefined => {
+  if (!key) {
+    return undefined;
+  }
+
+  return apiEnvironmentOptions.find((option) => option.key === key);
+};
+
+export const getDefaultApiEnvironmentKey = (): string => {
+  if (defaultEnvironmentKey && findApiEnvironmentOption(defaultEnvironmentKey)) {
+    return defaultEnvironmentKey;
+  }
+
+  const firstWithBackend = apiEnvironmentOptions.find((option) => Boolean(option.baseUrl));
+  return firstWithBackend?.key ?? apiEnvironmentOptions[0]?.key ?? "mock";
+};
+
+export const getInitialApiEnvironmentKey = (): string => {
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem(API_ENV_STORAGE_KEY);
+    if (stored && findApiEnvironmentOption(stored)) {
+      return stored;
+    }
+  }
+
+  return getDefaultApiEnvironmentKey();
+};

--- a/apps/app-ui/src/features/auth/authSlice.ts
+++ b/apps/app-ui/src/features/auth/authSlice.ts
@@ -1,19 +1,15 @@
 import { createAsyncThunk, createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type {
+  AuthResponsePayload,
   LoginRequestPayload,
-  LoginResponsePayload,
   RegisterRequestPayload,
-  RegisterResponsePayload,
 } from "@rc/api-client";
 import { ApiError } from "@rc/api-client";
 import { authApi } from "../../services/api";
 
 export type AuthUiMode = "login" | "register";
 
-export interface LoginFormValues extends LoginRequestPayload {}
-export interface RegisterFormValues extends RegisterRequestPayload {
-  confirmPassword: string;
-}
+export type LoginFormValues = LoginRequestPayload;
 
 interface AuthState {
   modalOpen: boolean;
@@ -30,7 +26,7 @@ const initialState: AuthState = {
 };
 
 export const submitLogin = createAsyncThunk<
-  LoginResponsePayload,
+  AuthResponsePayload,
   LoginFormValues,
   { rejectValue: string }
 >("auth/submitLogin", async (payload, { rejectWithValue }) => {
@@ -45,13 +41,12 @@ export const submitLogin = createAsyncThunk<
 });
 
 export const submitRegistration = createAsyncThunk<
-  RegisterResponsePayload,
-  RegisterFormValues,
+  AuthResponsePayload,
+  RegisterRequestPayload,
   { rejectValue: string }
 >("auth/submitRegistration", async (payload, { rejectWithValue }) => {
-  const { confirmPassword, ...request } = payload;
   try {
-    return await authApi.register(request);
+    return await authApi.register(payload);
   } catch (error) {
     if (error instanceof ApiError) {
       return rejectWithValue(error.message);
@@ -90,6 +85,7 @@ const authSlice = createSlice({
       })
       .addCase(submitLogin.fulfilled, (state) => {
         state.status = "succeeded";
+        state.modalOpen = false;
       })
       .addCase(submitLogin.rejected, (state, action) => {
         state.status = "failed";
@@ -101,6 +97,7 @@ const authSlice = createSlice({
       })
       .addCase(submitRegistration.fulfilled, (state) => {
         state.status = "succeeded";
+        state.modalOpen = false;
       })
       .addCase(submitRegistration.rejected, (state, action) => {
         state.status = "failed";

--- a/apps/app-ui/src/features/environment/environmentSlice.ts
+++ b/apps/app-ui/src/features/environment/environmentSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import {
+  apiEnvironmentOptions,
+  getInitialApiEnvironmentKey,
+} from "../../config/api-environments";
+
+interface EnvironmentState {
+  currentKey: string;
+}
+
+const initialState: EnvironmentState = {
+  currentKey: getInitialApiEnvironmentKey(),
+};
+
+const environmentSlice = createSlice({
+  name: "environment",
+  initialState,
+  reducers: {
+    setApiEnvironment(state, action: PayloadAction<string>) {
+      const isValid = apiEnvironmentOptions.some((option) => option.key === action.payload);
+      if (isValid) {
+        state.currentKey = action.payload;
+      }
+    },
+  },
+});
+
+export const { setApiEnvironment } = environmentSlice.actions;
+export const environmentReducer = environmentSlice.reducer;

--- a/apps/app-ui/src/features/environment/selectors.ts
+++ b/apps/app-ui/src/features/environment/selectors.ts
@@ -1,0 +1,7 @@
+import { findApiEnvironmentOption } from "../../config/api-environments";
+import type { RootState } from "../../store/store";
+
+export const selectEnvironmentState = (state: RootState) => state.environment;
+export const selectCurrentEnvironmentKey = (state: RootState) => state.environment.currentKey;
+export const selectCurrentEnvironment = (state: RootState) =>
+  findApiEnvironmentOption(selectCurrentEnvironmentKey(state));

--- a/apps/app-ui/src/providers/AppProvider.tsx
+++ b/apps/app-ui/src/providers/AppProvider.tsx
@@ -2,9 +2,17 @@ import { ConfigProvider } from "antd";
 import type { FC, PropsWithChildren } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Provider } from "react-redux";
+import { selectCurrentEnvironment } from "../features/environment/selectors";
+import { setApiEnvironment } from "../features/environment/environmentSlice";
+import {
+  API_ENV_STORAGE_KEY,
+  getDefaultApiEnvironmentKey,
+} from "../config/api-environments";
+import { setApiBaseUrl } from "../services/api";
 import { darkThemeConfig } from "../themes/dark-theme";
 import { lightThemeConfig } from "../themes/light-theme";
 import { store } from "../store/store";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
 import type { ThemeMode } from "./theme-mode-context";
 import { ThemeModeContext } from "./theme-mode-context";
 
@@ -27,6 +35,26 @@ const getInitialThemeMode = (): ThemeMode => {
   }
 
   return "dark";
+};
+
+const ApiEnvironmentBridge: FC = () => {
+  const dispatch = useAppDispatch();
+  const environment = useAppSelector(selectCurrentEnvironment);
+
+  useEffect(() => {
+    if (!environment) {
+      dispatch(setApiEnvironment(getDefaultApiEnvironmentKey()));
+      return;
+    }
+
+    setApiBaseUrl(environment.baseUrl);
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(API_ENV_STORAGE_KEY, environment.key);
+    }
+  }, [environment, dispatch]);
+
+  return null;
 };
 
 export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -92,6 +120,7 @@ export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
     <Provider store={store}>
       <ThemeModeContext.Provider value={contextValue}>
+        <ApiEnvironmentBridge />
         <ConfigProvider theme={themeConfig}>{children}</ConfigProvider>
       </ThemeModeContext.Provider>
     </Provider>

--- a/apps/app-ui/src/services/api.ts
+++ b/apps/app-ui/src/services/api.ts
@@ -3,7 +3,13 @@ import { createApiLayer } from "@rc/api-client";
 const baseUrl = (import.meta.env?.VITE_API_BASE_URL as string | undefined)?.trim();
 
 export const apiLayer = createApiLayer({
-  baseUrl: baseUrl || undefined,
+  baseUrl: baseUrl ? baseUrl : undefined,
 });
+
+export const setApiBaseUrl = (nextBaseUrl?: string) => {
+  apiLayer.client.setBaseUrl(nextBaseUrl && nextBaseUrl.trim() ? nextBaseUrl : undefined);
+};
+
+export const getApiBaseUrl = () => apiLayer.client.getBaseUrl();
 
 export const authApi = apiLayer.auth;

--- a/apps/app-ui/src/store/store.ts
+++ b/apps/app-ui/src/store/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { arenaReducer } from "../features/arena/arenaSlice";
 import { authReducer } from "../features/auth/authSlice";
+import { environmentReducer } from "../features/environment/environmentSlice";
 
 export const store = configureStore({
   reducer: {
     arena: arenaReducer,
     auth: authReducer,
+    environment: environmentReducer,
   },
 });
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37,7 +37,7 @@ export const runCoreMigrations = async (): Promise<void> => {
         first_name VARCHAR(120) NOT NULL,
         last_name VARCHAR(120) NOT NULL,
         password_hash TEXT NOT NULL,
-        photo_path TEXT NOT NULL,
+        photo_path TEXT,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
     `);

--- a/packages/db/src/users.ts
+++ b/packages/db/src/users.ts
@@ -7,7 +7,7 @@ export type DbUserRow = {
   first_name: string;
   last_name: string;
   password_hash: string;
-  photo_path: string;
+  photo_path: string | null;
   created_at: Date;
 };
 
@@ -17,7 +17,7 @@ export type CreateUserPayload = {
   firstName: string;
   lastName: string;
   passwordHash: string;
-  photoPath: string;
+  photoPath: string | null;
 };
 
 export const insertUser = async (payload: CreateUserPayload): Promise<DbUserRow> => {


### PR DESCRIPTION
## Summary
- allow account registration without requiring a profile photo and store a nullable photo path in the database
- update the shared API client and auth UI to post backend-compatible payloads, including optional avatar uploads
- add configurable backend environment options with a navbar switcher that synchronizes the active API base URL

## Testing
- pnpm --filter app-ui lint
- pnpm --filter app-backend lint *(fails: ESLint config not migrated in backend package)*

------
https://chatgpt.com/codex/tasks/task_e_68df65d5f85483258668c7d209df64bd