### PR TITLE
feat: scaffold file manager service infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 coverage/
 .env
 .DS_Store
+
+# TypeScript build info
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -56,10 +56,22 @@ codebattle-arena/
 │   └── app-backend/   # Node.js authentication + orchestration API
 │
 ├── packages/
-│   └── db/            # Shared Postgres connector utilities
+│   ├── db/                    # Shared Postgres connector utilities
+│   └── file-manager-service/  # Markdown problem storage microservice
 │
 ├── package.json
 └── pnpm-workspace.yaml
+
+## 🗂️ File Manager Service
+
+The monorepo now includes a dedicated File Manager HTTP service responsible for storing Markdown problem statements on a shared volume. Key capabilities include:
+
+- REST endpoints to list, read, and create Markdown problems.
+- Configurable storage root via the `PROBLEM_STORAGE_ROOT` environment variable.
+- Enforced payload limits (`FILE_MANAGER_MAX_SIZE_MB`) to prevent oversized uploads.
+- Docker Compose integration with a persistent `problem_markdown_data` volume shared with the backend.
+
+> The service lives under [`packages/file-manager-service`](packages/file-manager-service) and ships with a Dockerfile so it can run alongside the rest of the stack.
 
 ## 🗄️ Backend Overview
 

--- a/apps/app-backend/README.md
+++ b/apps/app-backend/README.md
@@ -92,6 +92,7 @@ See the [Docker](#docker) section for more details.
 The backend ships with a Compose file that starts:
 
 - `app-backend`: Node.js service running on port 4000.
+- `file-manager`: Dedicated Markdown storage service exposed on port 4100 and sharing the `problem_markdown_data` volume.
 - `postgres`: Postgres 15 database with a named volume for persistence.
 
 Available scripts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,26 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      file-manager:
+        condition: service_started
     volumes:
       - ./apps/app-backend/storage:/app/apps/app-backend/storage
+      - problem_markdown_data:/app/storage/problems
+    restart: unless-stopped
+
+  file-manager:
+    build:
+      context: .
+      dockerfile: packages/file-manager-service/Dockerfile
+    environment:
+      NODE_ENV: development
+      FILE_MANAGER_PORT: 4100
+      PROBLEM_STORAGE_ROOT: /app/storage/problems
+      FILE_MANAGER_MAX_SIZE_MB: 2
+    ports:
+      - "4100:4100"
+    volumes:
+      - problem_markdown_data:/app/storage/problems
     restart: unless-stopped
 
   postgres:
@@ -45,3 +63,4 @@ services:
 
 volumes:
   postgres_data:
+  problem_markdown_data:

--- a/packages/file-manager-service/Dockerfile
+++ b/packages/file-manager-service/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS base
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.17.1 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter file-manager-service build
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.17.1 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY --from=base /app/node_modules ./node_modules
+COPY packages/file-manager-service/package.json ./packages/file-manager-service/package.json
+COPY --from=base /app/packages/file-manager-service/dist ./packages/file-manager-service/dist
+
+ENV NODE_ENV=production
+ENV FILE_MANAGER_PORT=4100
+ENV PROBLEM_STORAGE_ROOT=/app/storage/problems
+ENV FILE_MANAGER_MAX_SIZE_MB=2
+
+EXPOSE 4100
+
+CMD ["pnpm", "--filter", "file-manager-service", "start"]

--- a/packages/file-manager-service/README.md
+++ b/packages/file-manager-service/README.md
@@ -1,0 +1,32 @@
+# File Manager Service
+
+Dedicated HTTP service responsible for storing and retrieving Markdown-based coding problems for CodeBattle Arena.
+
+## Features
+
+- RESTful endpoints to list, fetch, and create problem statements stored as `.md` files.
+- Configurable storage directory so the service can share a Docker volume with other apps.
+- JSON-based upload flow that enforces payload limits via environment variables.
+- Hardened Express middleware stack (Helmet, CORS, logging) suitable for local development.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `FILE_MANAGER_PORT` | Port where the HTTP server listens. | `4100` |
+| `PROBLEM_STORAGE_ROOT` | Absolute path where Markdown files are stored. | `<repo>/problems` when running locally, `/app/storage/problems` in Docker |
+| `FILE_MANAGER_MAX_SIZE_MB` | Maximum payload size for problem creation requests (in megabytes). | `2` |
+
+Set these values in your shell or Docker Compose file before starting the service.
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `pnpm --filter file-manager-service dev` | Start the service with hot reloading via `ts-node-dev`. |
+| `pnpm --filter file-manager-service build` | Compile TypeScript sources to JavaScript. |
+| `pnpm --filter file-manager-service start` | Run the compiled server from the `dist/` directory. |
+
+## Docker
+
+A dedicated [`Dockerfile`](./Dockerfile) is provided. The root `docker-compose.yml` wires the service up with a persistent volume named `problem_markdown_data` so Markdown files survive container restarts and can be shared with other services.

--- a/packages/file-manager-service/package.json
+++ b/packages/file-manager-service/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "file-manager-service",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Dedicated Markdown problem storage service for CodeBattle Arena",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc -b tsconfig.build.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "helmet": "^8.1.0",
+    "morgan": "^1.10.0",
+    "zod": "^3.24.1",
+    "http-errors": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.23",
+    "@types/morgan": "^1.9.9",
+    "@types/node": "^20.17.12",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "~5.8.3",
+    "@types/http-errors": "^2.0.4"
+  }
+}

--- a/packages/file-manager-service/src/config/env.ts
+++ b/packages/file-manager-service/src/config/env.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import { config } from 'dotenv';
+
+config();
+
+const parsePort = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parseSize = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export const env = {
+  nodeEnv: process.env.NODE_ENV ?? 'development',
+  port: parsePort(process.env.FILE_MANAGER_PORT, 4100),
+  storageRoot:
+    process.env.PROBLEM_STORAGE_ROOT ?? path.resolve(process.cwd(), 'problems'),
+  maxProblemSizeMb: parseSize(process.env.FILE_MANAGER_MAX_SIZE_MB, 2),
+};

--- a/packages/file-manager-service/src/index.ts
+++ b/packages/file-manager-service/src/index.ts
@@ -1,0 +1,17 @@
+import { env } from './config/env';
+import { createServer } from './server';
+
+const bootstrap = async (): Promise<void> => {
+  try {
+    const app = await createServer();
+    app.listen(env.port, () => {
+      // eslint-disable-next-line no-console
+      console.log(`File Manager service listening on port ${env.port}`);
+    });
+  } catch (error) {
+    console.error('Failed to start file-manager service', error);
+    process.exit(1);
+  }
+};
+
+void bootstrap();

--- a/packages/file-manager-service/src/routes/problems.ts
+++ b/packages/file-manager-service/src/routes/problems.ts
@@ -1,0 +1,58 @@
+import { Router, type NextFunction, type Request, type Response } from 'express';
+import createHttpError from 'http-errors';
+
+import type { CreateProblemInput } from '../services/problemStore';
+import { ProblemStore } from '../services/problemStore';
+
+export const createProblemRouter = (store: ProblemStore): Router => {
+  const router = Router();
+
+  router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const problems = await store.list();
+      res.json({ problems });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get(
+    '/:slug',
+    async (
+      req: Request<{ slug: string }>,
+      res: Response,
+      next: NextFunction,
+    ): Promise<void> => {
+      try {
+        const { slug } = req.params;
+        const problem = await store.read(slug);
+        res.json(problem);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          next(createHttpError(404, 'Problem not found'));
+          return;
+        }
+
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    '/',
+    async (
+      req: Request<unknown, unknown, CreateProblemInput>,
+      res: Response,
+      next: NextFunction,
+    ): Promise<void> => {
+      try {
+        const problem = await store.save(req.body);
+        res.status(201).json(problem);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+};

--- a/packages/file-manager-service/src/server.ts
+++ b/packages/file-manager-service/src/server.ts
@@ -1,0 +1,45 @@
+import express, { type Express, type NextFunction, type Request, type Response } from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import morgan from 'morgan';
+import createHttpError, { isHttpError } from 'http-errors';
+import type { HttpError } from 'http-errors';
+import { env } from './config/env';
+import { ensureDirectory } from './utils/files';
+import { ProblemStore } from './services/problemStore';
+import { createProblemRouter } from './routes/problems';
+
+export const createServer = async (): Promise<Express> => {
+  await ensureDirectory(env.storageRoot);
+
+  const app = express();
+  const store = new ProblemStore(env.storageRoot);
+
+  app.use(helmet());
+  app.use(cors());
+  app.use(express.json({ limit: `${env.maxProblemSizeMb}mb` }));
+  app.use(morgan(env.nodeEnv === 'development' ? 'dev' : 'combined'));
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.use('/problems', createProblemRouter(store));
+
+  app.use((_req: Request, _res: Response, next: NextFunction) => {
+    next(createHttpError(404, 'Route not found'));
+  });
+
+  app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    if (isHttpError(error)) {
+      const httpError = error as HttpError;
+      res.status(httpError.status).json({ message: httpError.message });
+      return;
+    }
+
+    console.error('Unexpected error in file-manager service', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  });
+
+  return app;
+};

--- a/packages/file-manager-service/src/services/problemStore.ts
+++ b/packages/file-manager-service/src/services/problemStore.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs/promises';
+import { Dirent } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { resolveProblemPath, sanitizeSlug } from '../utils/files';
+
+export type ProblemMetadata = {
+  slug: string;
+  filename: string;
+  updatedAt: string;
+};
+
+const createProblemSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  slug: z
+    .string()
+    .optional()
+    .transform((value) => (value ? sanitizeSlug(value) : undefined)),
+  content: z.string().min(1, 'Problem content is required'),
+});
+
+export type CreateProblemInput = z.infer<typeof createProblemSchema>;
+
+export class ProblemStore {
+  constructor(private readonly storageRoot: string) {}
+
+  async list(): Promise<ProblemMetadata[]> {
+    const entries: Dirent[] = await fs.readdir(this.storageRoot, { withFileTypes: true });
+
+    const markdownFiles = entries.filter((entry: Dirent) => entry.isFile() && entry.name.endsWith('.md'));
+
+    const stats = await Promise.all(
+      markdownFiles.map(async (entry: Dirent): Promise<ProblemMetadata> => {
+        const slug = path.basename(entry.name, '.md');
+        const filePath = path.join(this.storageRoot, entry.name);
+        const info = await fs.stat(filePath);
+
+        return {
+          slug,
+          filename: entry.name,
+          updatedAt: info.mtime.toISOString(),
+        } satisfies ProblemMetadata;
+      }),
+    );
+
+    stats.sort((a: ProblemMetadata, b: ProblemMetadata) => a.slug.localeCompare(b.slug));
+
+    return stats;
+  }
+
+  async read(slug: string): Promise<{ slug: string; content: string }> {
+    const sanitized = sanitizeSlug(slug);
+    const filePath = resolveProblemPath(this.storageRoot, sanitized);
+    const buffer = await fs.readFile(filePath);
+
+    return {
+      slug: sanitized,
+      content: buffer.toString('utf-8'),
+    };
+  }
+
+  async save(input: CreateProblemInput): Promise<ProblemMetadata & { content: string }> {
+    const parsed = createProblemSchema.parse(input);
+    const slug = parsed.slug ?? sanitizeSlug(parsed.title);
+    if (!slug) {
+      throw new Error('Problem slug cannot be empty after sanitization');
+    }
+
+    const filename = `${slug}.md`;
+    const filePath = resolveProblemPath(this.storageRoot, slug);
+
+    await fs.writeFile(filePath, parsed.content, 'utf-8');
+    const stats = await fs.stat(filePath);
+
+    return {
+      slug,
+      filename,
+      updatedAt: stats.mtime.toISOString(),
+      content: parsed.content,
+    };
+  }
+}

--- a/packages/file-manager-service/src/utils/files.ts
+++ b/packages/file-manager-service/src/utils/files.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const ensureDirectory = async (target: string): Promise<void> => {
+  await fs.mkdir(target, { recursive: true });
+};
+
+export const resolveProblemPath = (storageRoot: string, slug: string): string => {
+  return path.join(storageRoot, `${slug}.md`);
+};
+
+export const sanitizeSlug = (value: string): string => {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\-\s_]/g, '')
+    .trim()
+    .replace(/[\s_]+/g, '-');
+};

--- a/packages/file-manager-service/tsconfig.build.json
+++ b/packages/file-manager-service/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}

--- a/packages/file-manager-service/tsconfig.json
+++ b/packages/file-manager-service/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,52 @@ importers:
         specifier: ~5.8.3
         version: 5.8.3
 
+  packages/file-manager-service:
+    dependencies:
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      express:
+        specifier: ^4.21.2
+        version: 4.21.2
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
+      http-errors:
+        specifier: ^2.0.0
+        version: 2.0.0
+      morgan:
+        specifier: ^1.10.0
+        version: 1.10.1
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^4.17.23
+        version: 4.17.23
+      '@types/http-errors':
+        specifier: ^2.0.4
+        version: 2.0.5
+      '@types/morgan':
+        specifier: ^1.9.9
+        version: 1.9.10
+      '@types/node':
+        specifier: ^20.17.12
+        version: 20.19.19
+      ts-node-dev:
+        specifier: ^2.0.0
+        version: 2.0.0(@types/node@20.19.19)(typescript@5.8.3)
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
 packages:
 
   '@ant-design/colors@7.2.1':
@@ -906,6 +952,9 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
+  '@types/morgan@1.9.10':
+    resolution: {integrity: sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1100,6 +1149,10 @@ packages:
   baseline-browser-mapping@2.8.9:
     resolution: {integrity: sha512-hY/u2lxLrbecMEWSB0IpGzGyDyeoMFQhCvZd2jGFSE5I17Fh01sYUBPCJtkWERw7zrac9+cIghxm/ytJa2X8iA==}
     hasBin: true
+
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
@@ -1955,6 +2008,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  morgan@1.10.1:
+    resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
+    engines: {node: '>= 0.8.0'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -2013,8 +2070,16 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -3545,6 +3610,10 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
+  '@types/morgan@1.9.10':
+    dependencies:
+      '@types/node': 20.19.19
+
   '@types/ms@2.1.0': {}
 
   '@types/multer@1.4.13':
@@ -3855,6 +3924,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.8.9: {}
+
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   bcryptjs@2.4.3: {}
 
@@ -4825,6 +4898,16 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  morgan@1.10.1:
+    dependencies:
+      basic-auth: 2.0.1
+      debug: 2.6.9
+      depd: 2.0.0
+      on-finished: 2.3.0
+      on-headers: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -4884,9 +4967,15 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add a dedicated file-manager service package that exposes REST endpoints for Markdown problem storage
- integrate the service into docker-compose with a persistent `problem_markdown_data` volume shared with the backend
- document the service, its environment variables, and ignore TypeScript build info artifacts

## Testing
- pnpm --filter file-manager-service build

------
https://chatgpt.com/codex/tasks/task_e_68dfa503dd08832593e7bb24805cbbee