### PR TITLE
feat: add battle scheduling management

### DIFF
--- a/apps/app-backend/src/app.ts
+++ b/apps/app-backend/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import { env } from './config/env';
 import { authRouter } from './routes/auth';
+import { battleRouter } from './routes/battles';
 import { errorHandler } from './middleware/errorHandler';
 import { notFoundHandler } from './middleware/notFound';
 
@@ -15,6 +16,7 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use('/uploads', express.static(env.uploadsDir, { extensions: ['jpg', 'jpeg', 'png'] }));
 app.use('/api/auth', authRouter);
+app.use('/api/battles', battleRouter);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/app-backend/src/controllers/battleController.ts
+++ b/apps/app-backend/src/controllers/battleController.ts
@@ -1,0 +1,124 @@
+import type { NextFunction, Request, Response } from 'express';
+import { z } from 'zod';
+import {
+  createBattle,
+  getBattles,
+  startBattle,
+  updateBattle,
+  type BattleStartMode,
+} from '../services/battleService';
+
+const startModeSchema = z.enum(['manual', 'scheduled']);
+
+const battleStatusSchema = z.enum(['draft', 'configuring', 'ready', 'scheduled']);
+
+const createBattleSchema = z
+  .object({
+    name: z.string().min(1, 'Battle name is required'),
+    shortDescription: z.string().optional(),
+    configuration: z.record(z.any()).optional(),
+    startMode: startModeSchema,
+    scheduledStartAt: z.string().datetime().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.startMode === 'scheduled' && !value.scheduledStartAt) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'scheduledStartAt is required when startMode is scheduled',
+        path: ['scheduledStartAt'],
+      });
+    }
+  });
+
+const updateBattleSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    shortDescription: z.union([z.string(), z.null()]).optional(),
+    configuration: z.record(z.any()).optional(),
+    startMode: startModeSchema.optional(),
+    scheduledStartAt: z.union([z.string().datetime(), z.null()]).optional(),
+    status: battleStatusSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.startMode === 'scheduled' && value.scheduledStartAt === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'scheduledStartAt is required when startMode is scheduled',
+        path: ['scheduledStartAt'],
+      });
+    }
+  });
+
+const parseStartDate = (value: string | null | undefined): Date | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date;
+};
+
+export const listBattlesHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const battles = await getBattles();
+    res.json({ battles });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createBattleHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const payload = createBattleSchema.parse(req.body);
+    const startDate = parseStartDate(payload.scheduledStartAt ?? undefined);
+
+    const battle = await createBattle({
+      name: payload.name,
+      shortDescription: payload.shortDescription ?? null,
+      configuration: payload.configuration,
+      startMode: payload.startMode as BattleStartMode,
+      scheduledStartAt: startDate ?? null,
+    });
+
+    res.status(201).json({ battle });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateBattleHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const payload = updateBattleSchema.parse(req.body);
+    const startDate = parseStartDate(payload.scheduledStartAt ?? undefined);
+
+    const battle = await updateBattle(req.params.battleId, {
+      name: payload.name,
+      shortDescription: payload.shortDescription ?? undefined,
+      configuration: payload.configuration,
+      startMode: payload.startMode as BattleStartMode | undefined,
+      scheduledStartAt: startDate,
+      status: payload.status,
+    });
+
+    res.json({ battle });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const startBattleHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const battle = await startBattle(req.params.battleId);
+    res.json({ battle });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/apps/app-backend/src/index.ts
+++ b/apps/app-backend/src/index.ts
@@ -3,6 +3,7 @@ import { env } from './config/env';
 import { app } from './app';
 import { ensureDirectory } from './utils/filesystem';
 import { logger } from './utils/logger';
+import { initializeBattleScheduling } from './services/battleService';
 
 const startServer = async (): Promise<void> => {
   try {
@@ -18,6 +19,7 @@ const startServer = async (): Promise<void> => {
     });
 
     await runCoreMigrations();
+    await initializeBattleScheduling();
 
     app.listen(env.port, () => {
       logger.info(`Backend listening on port ${env.port}`);

--- a/apps/app-backend/src/routes/battles.ts
+++ b/apps/app-backend/src/routes/battles.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import {
+  createBattleHandler,
+  listBattlesHandler,
+  startBattleHandler,
+  updateBattleHandler,
+} from '../controllers/battleController';
+
+export const battleRouter = Router();
+
+battleRouter.get('/', listBattlesHandler);
+battleRouter.post('/', createBattleHandler);
+battleRouter.patch('/:battleId', updateBattleHandler);
+battleRouter.post('/:battleId/start', startBattleHandler);

--- a/apps/app-backend/src/services/battleService.ts
+++ b/apps/app-backend/src/services/battleService.ts
@@ -1,0 +1,323 @@
+import createHttpError from 'http-errors';
+import { v4 as uuid } from 'uuid';
+import {
+  insertBattle,
+  listBattles,
+  updateBattleById,
+  findBattleById,
+  listScheduledBattles,
+  type BattleStatus,
+  type DbBattleRow,
+  type UpdateBattlePayload,
+} from '@codebattle/db';
+import { logger } from '../utils/logger';
+
+export type BattleStartMode = 'manual' | 'scheduled';
+
+export type BattleRecord = {
+  id: string;
+  name: string;
+  shortDescription: string | null;
+  status: BattleStatus;
+  configuration: Record<string, unknown>;
+  autoStart: boolean;
+  scheduledStartAt: string | null;
+  startedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateBattleInput = {
+  name: string;
+  shortDescription?: string | null;
+  configuration?: Record<string, unknown>;
+  startMode: BattleStartMode;
+  scheduledStartAt?: Date | null;
+};
+
+export type UpdateBattleInput = Partial<CreateBattleInput> & {
+  status?: BattleStatus;
+};
+
+const CONFIGURABLE_STATUSES: BattleStatus[] = ['draft', 'configuring', 'ready', 'scheduled'];
+
+const toBattleRecord = (row: DbBattleRow): BattleRecord => ({
+  id: row.id,
+  name: row.name,
+  shortDescription: row.short_description,
+  status: row.status,
+  configuration: row.configuration ?? {},
+  autoStart: row.auto_start,
+  scheduledStartAt: row.scheduled_start_at ? row.scheduled_start_at.toISOString() : null,
+  startedAt: row.started_at ? row.started_at.toISOString() : null,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+class BattleScheduler {
+  private timers = new Map<string, NodeJS.Timeout>();
+
+  schedule(row: DbBattleRow, start: (battleId: string) => Promise<void>): void {
+    if (!row.scheduled_start_at) {
+      this.cancel(row.id);
+      return;
+    }
+
+    const delay = row.scheduled_start_at.getTime() - Date.now();
+    if (delay <= 0) {
+      this.cancel(row.id);
+      void start(row.id);
+      return;
+    }
+
+    this.cancel(row.id);
+    const timer = setTimeout(() => {
+      this.timers.delete(row.id);
+      void start(row.id);
+    }, delay);
+
+    this.timers.set(row.id, timer);
+  }
+
+  cancel(battleId: string): void {
+    const timer = this.timers.get(battleId);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(battleId);
+    }
+  }
+
+  async restore(start: (battleId: string) => Promise<void>): Promise<void> {
+    const scheduledBattles = await listScheduledBattles();
+    scheduledBattles.forEach((battle) => {
+      this.schedule(battle, start);
+    });
+  }
+}
+
+const scheduler = new BattleScheduler();
+
+const sanitizeName = (name: string): string => {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw createHttpError(400, 'Battle name is required');
+  }
+  return trimmed;
+};
+
+const normalizeShortDescription = (value: string | null | undefined): string | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const determineStartPlan = (
+  startMode: BattleStartMode,
+  scheduledStartAt?: Date | null,
+): {
+  status: BattleStatus;
+  autoStart: boolean;
+  scheduledStartAt: Date | null;
+  startedAt: Date | null;
+} => {
+  if (startMode === 'scheduled' && scheduledStartAt) {
+    if (scheduledStartAt.getTime() <= Date.now()) {
+      return {
+        status: 'active',
+        autoStart: false,
+        scheduledStartAt: null,
+        startedAt: new Date(),
+      };
+    }
+
+    return {
+      status: 'scheduled',
+      autoStart: true,
+      scheduledStartAt,
+      startedAt: null,
+    };
+  }
+
+  return {
+    status: 'draft',
+    autoStart: false,
+    scheduledStartAt: null,
+    startedAt: null,
+  };
+};
+
+const determineUpdatePlan = (
+  existing: DbBattleRow,
+  startMode: BattleStartMode,
+  scheduledStartAt?: Date | null,
+  explicitStatus?: BattleStatus,
+): {
+  status: BattleStatus;
+  autoStart: boolean;
+  scheduledStartAt: Date | null;
+  startedAt: Date | null;
+} => {
+  if (explicitStatus) {
+    return {
+      status: explicitStatus,
+      autoStart: startMode === 'scheduled',
+      scheduledStartAt: startMode === 'scheduled' ? scheduledStartAt ?? existing.scheduled_start_at : null,
+      startedAt: explicitStatus === 'active' ? existing.started_at ?? new Date() : existing.started_at,
+    };
+  }
+
+  if (startMode === 'scheduled' && scheduledStartAt) {
+    if (scheduledStartAt.getTime() <= Date.now()) {
+      return {
+        status: 'active',
+        autoStart: false,
+        scheduledStartAt: null,
+        startedAt: new Date(),
+      };
+    }
+
+    return {
+      status: 'scheduled',
+      autoStart: true,
+      scheduledStartAt,
+      startedAt: existing.started_at,
+    };
+  }
+
+  return {
+    status: 'ready',
+    autoStart: false,
+    scheduledStartAt: null,
+    startedAt: existing.started_at,
+  };
+};
+
+export const initializeBattleScheduling = async (): Promise<void> => {
+  await scheduler.restore(async (battleId) => {
+    try {
+      await startBattle(battleId);
+    } catch (error) {
+      logger.error(`Failed to auto-start battle ${battleId}`, error);
+    }
+  });
+};
+
+export const getBattles = async (): Promise<BattleRecord[]> => {
+  const rows = await listBattles();
+  return rows.map(toBattleRecord);
+};
+
+export const createBattle = async (input: CreateBattleInput): Promise<BattleRecord> => {
+  const name = sanitizeName(input.name);
+  const shortDescription = normalizeShortDescription(input.shortDescription);
+  const configuration = input.configuration ?? {};
+
+  const plan = determineStartPlan(input.startMode, input.scheduledStartAt ?? null);
+  const battleId = uuid();
+
+  const created = await insertBattle({
+    id: battleId,
+    name,
+    shortDescription: shortDescription ?? null,
+    status: plan.status,
+    configuration,
+    autoStart: plan.autoStart,
+    scheduledStartAt: plan.scheduledStartAt,
+    startedAt: plan.startedAt,
+  });
+
+  if (plan.status === 'scheduled') {
+    scheduler.schedule(created, (battleIdToStart) => startBattle(battleIdToStart));
+  }
+
+  return toBattleRecord(created);
+};
+
+export const updateBattle = async (id: string, input: UpdateBattleInput): Promise<BattleRecord> => {
+  const existing = await findBattleById(id);
+  if (!existing) {
+    throw createHttpError(404, 'Battle not found');
+  }
+
+  if (!CONFIGURABLE_STATUSES.includes(existing.status)) {
+    throw createHttpError(409, `Battles in status "${existing.status}" cannot be configured`);
+  }
+
+  const startMode = input.startMode ?? (existing.auto_start ? 'scheduled' : 'manual');
+  const shortDescription = normalizeShortDescription(input.shortDescription ?? undefined);
+  const configuration = input.configuration ?? existing.configuration ?? {};
+  const plan = determineUpdatePlan(
+    existing,
+    startMode,
+    input.scheduledStartAt ?? existing.scheduled_start_at,
+    input.status,
+  );
+
+  const updates: UpdateBattlePayload = {
+    status: plan.status,
+    autoStart: plan.autoStart,
+    scheduledStartAt: plan.scheduledStartAt,
+    startedAt: plan.startedAt,
+  };
+
+  if (input.name) {
+    updates.name = sanitizeName(input.name);
+  }
+
+  if (shortDescription !== undefined) {
+    updates.shortDescription = shortDescription;
+  }
+
+  if (input.configuration !== undefined) {
+    updates.configuration = configuration;
+  }
+
+  const updated = await updateBattleById(id, updates);
+
+  if (!updated) {
+    throw createHttpError(404, 'Battle not found');
+  }
+
+  if (plan.status === 'scheduled') {
+    scheduler.schedule(updated, (battleIdToStart) => startBattle(battleIdToStart));
+  } else {
+    scheduler.cancel(id);
+  }
+
+  return toBattleRecord(updated);
+};
+
+export const startBattle = async (id: string): Promise<BattleRecord> => {
+  const existing = await findBattleById(id);
+  if (!existing) {
+    throw createHttpError(404, 'Battle not found');
+  }
+
+  if (existing.status !== 'ready' && existing.status !== 'scheduled') {
+    throw createHttpError(409, `Battle cannot be started from status "${existing.status}"`);
+  }
+
+  scheduler.cancel(id);
+
+  const updated = await updateBattleById(id, {
+    status: 'active',
+    autoStart: false,
+    scheduledStartAt: null,
+    startedAt: existing.started_at ?? new Date(),
+  });
+
+  if (!updated) {
+    throw createHttpError(404, 'Battle not found');
+  }
+
+  return toBattleRecord(updated);
+};
+
+export const isConfigurableStatus = (status: BattleStatus): boolean => CONFIGURABLE_STATUSES.includes(status);

--- a/apps/app-ui/package.json
+++ b/apps/app-ui/package.json
@@ -16,6 +16,7 @@
     "@rc/api-client": "workspace:*",
     "@reduxjs/toolkit": "^2.9.0",
     "antd": "^5.27.4",
+    "dayjs": "^1.11.13",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-redux": "^9.2.0",

--- a/apps/app-ui/src/services/api.ts
+++ b/apps/app-ui/src/services/api.ts
@@ -13,3 +13,4 @@ export const setApiBaseUrl = (nextBaseUrl?: string) => {
 export const getApiBaseUrl = () => apiLayer.client.getBaseUrl();
 
 export const authApi = apiLayer.auth;
+export const battleApi = apiLayer.battles;

--- a/packages/db/src/battles.ts
+++ b/packages/db/src/battles.ts
@@ -1,0 +1,152 @@
+import type { QueryResult } from 'pg';
+import { getPool } from './index';
+
+export type BattleStatus =
+  | 'draft'
+  | 'configuring'
+  | 'scheduled'
+  | 'ready'
+  | 'active'
+  | 'completed'
+  | 'cancelled';
+
+export type DbBattleRow = {
+  id: string;
+  name: string;
+  short_description: string | null;
+  status: BattleStatus;
+  configuration: Record<string, unknown>;
+  auto_start: boolean;
+  scheduled_start_at: Date | null;
+  started_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export type CreateBattlePayload = {
+  id: string;
+  name: string;
+  shortDescription?: string | null;
+  status: BattleStatus;
+  configuration: Record<string, unknown>;
+  autoStart: boolean;
+  scheduledStartAt?: Date | null;
+  startedAt?: Date | null;
+};
+
+export type UpdateBattlePayload = Partial<{
+  name: string;
+  shortDescription: string | null;
+  status: BattleStatus;
+  configuration: Record<string, unknown>;
+  autoStart: boolean;
+  scheduledStartAt: Date | null;
+  startedAt: Date | null;
+}>;
+
+const columnMap: Record<keyof UpdateBattlePayload, string> = {
+  name: 'name',
+  shortDescription: 'short_description',
+  status: 'status',
+  configuration: 'configuration',
+  autoStart: 'auto_start',
+  scheduledStartAt: 'scheduled_start_at',
+  startedAt: 'started_at',
+};
+
+export const insertBattle = async (payload: CreateBattlePayload): Promise<DbBattleRow> => {
+  const pool = getPool();
+  const result: QueryResult<DbBattleRow> = await pool.query(
+    `
+      INSERT INTO battles (
+        id,
+        name,
+        short_description,
+        status,
+        configuration,
+        auto_start,
+        scheduled_start_at,
+        started_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING *
+    `,
+    [
+      payload.id,
+      payload.name,
+      payload.shortDescription ?? null,
+      payload.status,
+      payload.configuration,
+      payload.autoStart,
+      payload.scheduledStartAt ?? null,
+      payload.startedAt ?? null,
+    ],
+  );
+
+  return result.rows[0];
+};
+
+export const listBattles = async (): Promise<DbBattleRow[]> => {
+  const pool = getPool();
+  const result: QueryResult<DbBattleRow> = await pool.query(
+    `
+      SELECT *
+      FROM battles
+      ORDER BY created_at DESC
+    `,
+  );
+
+  return result.rows;
+};
+
+export const findBattleById = async (id: string): Promise<DbBattleRow | null> => {
+  const pool = getPool();
+  const result: QueryResult<DbBattleRow> = await pool.query(
+    `
+      SELECT *
+      FROM battles
+      WHERE id = $1
+    `,
+    [id],
+  );
+
+  return result.rows[0] ?? null;
+};
+
+export const listScheduledBattles = async (): Promise<DbBattleRow[]> => {
+  const pool = getPool();
+  const result: QueryResult<DbBattleRow> = await pool.query(
+    `
+      SELECT *
+      FROM battles
+      WHERE status = 'scheduled'
+      ORDER BY scheduled_start_at ASC NULLS LAST
+    `,
+  );
+
+  return result.rows;
+};
+
+export const updateBattleById = async (id: string, payload: UpdateBattlePayload): Promise<DbBattleRow | null> => {
+  const entries = (Object.entries(payload) as [keyof UpdateBattlePayload, unknown][]).filter(
+    ([, value]) => value !== undefined,
+  );
+
+  const assignments: string[] = entries.map(([key], index) => `${columnMap[key]} = $${index + 1}`);
+  const values = entries.map(([, value]) => value);
+
+  const setClause = assignments.length > 0 ? `${assignments.join(', ')}, ` : '';
+
+  const pool = getPool();
+  const result: QueryResult<DbBattleRow> = await pool.query(
+    `
+      UPDATE battles
+      SET ${setClause}updated_at = NOW()
+      WHERE id = $${assignments.length + 1}
+      RETURNING *
+    `,
+    [...values, id],
+  );
+
+  return result.rows[0] ?? null;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       antd:
         specifier: ^5.27.4
         version: 5.27.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.18
       react:
         specifier: ^19.1.1
         version: 19.1.1


### PR DESCRIPTION
## Summary
- add database schema and helpers for battle records, including scheduling metadata
- implement backend services, controllers, and routes to create, update, list, and start battles with auto-start timers
- expose battle APIs to the frontend and build a management UI for creating, scheduling, and launching battles

## Testing
- pnpm --filter app-ui lint
- pnpm --filter app-backend lint (fails: ESLint v9 requires eslint.config.js)

------
https://chatgpt.com/codex/tasks/task_e_68dfa4d50d5083259968a3e2aa26420f