### PR TITLE
Refactor host battle UI into Redux-driven modules

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -15,7 +15,7 @@
 | BATT-003 | Battle Service | Support battle start triggers (admin action or scheduled timer) and transition to active state. | TODO | Requires integration with queue bootstrap. |
 | INF-001 | Infrastructure | Add dedicated file-manager service and persistent Docker volume for Markdown problem storage. | TODO | Update docker-compose and environment docs. |
 | SV-001 | File Manager Service | Scaffold API to upload/list/read/delete .md problems stored on shared volume. | TODO | Provide metadata (hash, slug) for battle service. |
-| UI-001 | Admin UI | Allow battle admins to manage configuration and attach problems from file manager. | TODO | Requires new views and API hooks. |
+| UI-001 | Admin UI | Allow battle admins to manage configuration and attach problems from file manager. | IN_PROGRESS | Host battle admin view now wired through Redux; file manager integrations still pending. |
 | RUNTIME-001 | Runtime Orchestration | Provision per-user execution pods or containers to run submissions securely. | TODO | Decide on container runtime strategy. |
 | SV-002 | Runner Service | Implement service that receives run requests and executes code in user pod, emitting completion status. | TODO | Needs messaging contract with queue and sync services. |
 | SV-003 | Queue Service | Build queue processor to dispatch submissions to runner pods and manage back-pressure. | TODO | Define queue storage (Redis, NATS, etc.). |

--- a/apps/app-ui/src/App.tsx
+++ b/apps/app-ui/src/App.tsx
@@ -6,7 +6,7 @@ import { AuthModal } from "./components/auth/AuthModal";
 import { AppNavbar } from "./components/common/AppNavbar";
 import { HeroSection } from "./components/Hero/HeroSection";
 import { useThemeMode } from "./providers/theme-mode-context";
-import { HostBattlePage } from "./pages/HostBattlePage";
+import { HostBattlePage } from "./pages/host-battle";
 
 const App: FC = () => {
   const { token } = theme.useToken();

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/HostBattleForm.tsx
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/HostBattleForm.tsx
@@ -1,0 +1,70 @@
+import { Divider, Form, Typography } from "antd";
+import type { FormInstance } from "antd";
+import type { FC } from "react";
+import { useCallback, useMemo } from "react";
+import type { HostBattleFormValues } from "../../../features/hostBattle/types";
+import { baseFormDefaults } from "../../../features/hostBattle/utils";
+import { AdvancedSettingsSection } from "./sections/AdvancedSettingsSection";
+import { AdvancedToggle } from "./sections/AdvancedToggle";
+import { BasicSettingsSection } from "./sections/BasicSettingsSection";
+import { FormActions } from "./sections/FormActions";
+
+export interface HostBattleFormProps {
+  form: FormInstance<HostBattleFormValues>;
+  showAdvanced: boolean;
+  onToggleAdvanced: (checked: boolean) => void;
+  onSubmit: (values: HostBattleFormValues) => void;
+  submitButtonLabel?: string;
+  submitButtonLoading?: boolean;
+  onReset?: () => void;
+}
+
+export const HostBattleForm: FC<HostBattleFormProps> = ({
+  form,
+  showAdvanced,
+  onToggleAdvanced,
+  onSubmit,
+  submitButtonLabel = "Create battle",
+  submitButtonLoading = false,
+  onReset,
+}) => {
+  const initialValues = useMemo<Partial<HostBattleFormValues>>(
+    () => ({
+      ...baseFormDefaults,
+    }),
+    [],
+  );
+
+  const handleReset = useCallback(() => {
+    if (onReset) {
+      onReset();
+      return;
+    }
+
+    form.resetFields();
+    onToggleAdvanced(false);
+  }, [form, onReset, onToggleAdvanced]);
+
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      initialValues={initialValues}
+      onFinish={onSubmit}
+      requiredMark="optional"
+    >
+      <Typography.Title level={5} style={{ marginBottom: 16 }}>
+        Battle basics
+      </Typography.Title>
+      <BasicSettingsSection form={form} />
+      <Divider />
+      <AdvancedToggle checked={showAdvanced} onChange={onToggleAdvanced} />
+      <AdvancedSettingsSection form={form} visible={showAdvanced} />
+      <FormActions
+        onReset={handleReset}
+        submitButtonLabel={submitButtonLabel}
+        submitButtonLoading={submitButtonLoading}
+      />
+    </Form>
+  );
+};

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/formOptions.ts
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/formOptions.ts
@@ -1,0 +1,59 @@
+import type { ColProps } from "antd";
+
+export const basicSelectOptions = {
+  gameModes: [
+    { label: "Head-to-head", value: "head-to-head" },
+    { label: "Team battle", value: "team" },
+    { label: "Battle royale", value: "royale" },
+  ],
+  difficulty: [
+    { label: "Beginner", value: "beginner" },
+    { label: "Intermediate", value: "intermediate" },
+    { label: "Expert", value: "expert" },
+  ],
+};
+
+export const advancedSelectOptions = {
+  scoringRules: [
+    { label: "Points per challenge", value: "points-per-challenge" },
+    { label: "Time weighted", value: "time-weighted" },
+    { label: "First-to-finish", value: "first-to-finish" },
+  ],
+  tieBreaks: [
+    { label: "Fastest submission", value: "fastest-submission" },
+    { label: "Highest accuracy", value: "highest-accuracy" },
+    { label: "Rematch", value: "rematch" },
+  ],
+  powerUps: [
+    { label: "Hint reveal", value: "hint" },
+    { label: "Time freeze", value: "time-freeze" },
+    { label: "Double points", value: "double-points" },
+  ],
+  moderatorRoles: [
+    { label: "Judge", value: "judge" },
+    { label: "Streamer", value: "streamer" },
+    { label: "Scorekeeper", value: "scorekeeper" },
+  ],
+  resources: [
+    { label: "Starter template", value: "starter-template" },
+    { label: "Sample data pack", value: "sample-data" },
+    { label: "Benchmark suite", value: "benchmark" },
+  ],
+  linkExpiry: [
+    { label: "Never", value: "never" },
+    { label: "24 hours", value: "24h" },
+    { label: "7 days", value: "7d" },
+    { label: "Custom", value: "custom" },
+  ],
+};
+
+export const fieldColProps: ColProps = {
+  xs: 24,
+  md: 12,
+};
+
+export const advancedColProps: ColProps = {
+  xs: 24,
+  md: 12,
+  lg: 8,
+};

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/index.ts
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/index.ts
@@ -1,0 +1,3 @@
+export { HostBattleForm } from "./HostBattleForm";
+export type { HostBattleFormProps } from "./HostBattleForm";
+export type { HostBattleFormValues, StartMode, PrivacySetting } from "../../../features/hostBattle/types";

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/AdvancedSettingsSection.tsx
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/AdvancedSettingsSection.tsx
@@ -1,0 +1,139 @@
+import { Col, Form, InputNumber, Input, Row, Select, Space, Switch, Typography } from "antd";
+import type { FormInstance } from "antd";
+import type { FC } from "react";
+import { advancedSelectOptions, advancedColProps } from "../formOptions";
+import type { HostBattleFormValues, PrivacySetting } from "../../../features/hostBattle/types";
+
+interface AdvancedSettingsSectionProps {
+  form: FormInstance<HostBattleFormValues>;
+  visible: boolean;
+}
+
+export const AdvancedSettingsSection: FC<AdvancedSettingsSectionProps> = ({ form, visible }) => {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Space direction="vertical" size={24} style={{ width: "100%", marginTop: 16 }}>
+      <Typography.Title level={5} style={{ marginBottom: 0 }}>
+        Advanced settings
+      </Typography.Title>
+      <Row gutter={[16, 16]} align="top">
+        <Col {...advancedColProps}>
+          <Form.Item name="turnTimeLimit" label="Turn time limit (seconds)">
+            <InputNumber min={10} max={600} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="totalDuration" label="Total battle duration (minutes)">
+            <InputNumber min={5} max={240} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="scoringRules" label="Scoring rules">
+            <Select
+              placeholder="Choose scoring rules"
+              popupClassName="host-battle-select-dropdown"
+              options={advancedSelectOptions.scoringRules}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="tieBreakPreference" label="Tie-break preference">
+            <Select
+              placeholder="Choose tie-breaker"
+              popupClassName="host-battle-select-dropdown"
+              options={advancedSelectOptions.tieBreaks}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="powerUps" label="Power-up pool">
+            <Select
+              mode="multiple"
+              placeholder="Select power-ups"
+              popupClassName="host-battle-select-dropdown"
+              options={advancedSelectOptions.powerUps}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="teamBalancing" label="Team balancing" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="ratingFloor" label="Player rating floor">
+            <InputNumber min={0} max={5000} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="ratingCeiling" label="Player rating ceiling">
+            <InputNumber min={0} max={5000} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="moderatorRoles" label="Moderator roles">
+            <Select
+              mode="multiple"
+              placeholder="Assign moderators"
+              popupClassName="host-battle-select-dropdown"
+              options={advancedSelectOptions.moderatorRoles}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="preloadedResources" label="Pre-loaded resources">
+            <Select
+              placeholder="Select resources"
+              popupClassName="host-battle-select-dropdown"
+              options={advancedSelectOptions.resources}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="rematchDefaults" label="Rematch defaults" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="joinQueueSize" label="Queue size for join requests">
+            <InputNumber min={0} max={200} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item shouldUpdate noStyle>
+            {() => {
+              const privacy = form.getFieldValue("privacy") as PrivacySetting;
+              return (
+                <Form.Item name="password" label="Password">
+                  <Input.Password
+                    placeholder={privacy === "invite" ? "Share a secure password" : "Invite only required"}
+                    disabled={privacy !== "invite"}
+                    allowClear
+                  />
+                </Form.Item>
+              );
+            }}
+          </Form.Item>
+        </Col>
+        <Col {...advancedColProps}>
+          <Form.Item name="linkExpiry" label="Link expiry">
+            <Select
+              placeholder="Choose expiry"
+              popupClassName="host-battle-select-dropdown"
+              options={advancedSelectOptions.linkExpiry}
+              allowClear
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+    </Space>
+  );
+};

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/AdvancedToggle.tsx
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/AdvancedToggle.tsx
@@ -1,0 +1,16 @@
+import { Checkbox } from "antd";
+import type { CheckboxChangeEvent } from "antd/es/checkbox";
+import type { FC } from "react";
+
+interface AdvancedToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export const AdvancedToggle: FC<AdvancedToggleProps> = ({ checked, onChange }) => {
+  const handleChange = (event: CheckboxChangeEvent) => {
+    onChange(event.target.checked);
+  };
+
+  return <Checkbox checked={checked} onChange={handleChange}>Show advanced options</Checkbox>;
+};

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/BasicSettingsSection.tsx
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/BasicSettingsSection.tsx
@@ -1,0 +1,104 @@
+import { Col, DatePicker, Form, Input, InputNumber, Radio, Row, Select, Switch } from "antd";
+import type { FormInstance } from "antd";
+import type { FC } from "react";
+import { basicSelectOptions, fieldColProps } from "../formOptions";
+import type { HostBattleFormValues, StartMode } from "../../../features/hostBattle/types";
+
+interface BasicSettingsSectionProps {
+  form: FormInstance<HostBattleFormValues>;
+}
+
+export const BasicSettingsSection: FC<BasicSettingsSectionProps> = ({ form }) => (
+  <Row gutter={[16, 16]} align="top">
+    <Col {...fieldColProps}>
+      <Form.Item
+        name="battleName"
+        label="Battle name"
+        rules={[{ required: true, message: "Give your battle a name." }]}
+      >
+        <Input placeholder="Friday Night Algorithms" allowClear />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="shortDescription" label="Short description">
+        <Input placeholder="Add a quick pitch for players" allowClear />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="gameMode" label="Game mode">
+        <Select
+          placeholder="Select a mode"
+          popupClassName="host-battle-select-dropdown"
+          options={basicSelectOptions.gameModes}
+          allowClear
+        />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="difficulty" label="Difficulty">
+        <Select
+          placeholder="Select difficulty"
+          popupClassName="host-battle-select-dropdown"
+          options={basicSelectOptions.difficulty}
+          allowClear
+        />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="maxPlayers" label="Max players">
+        <InputNumber min={2} max={100} style={{ width: "100%" }} />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="privacy" label="Privacy">
+        <Radio.Group optionType="button" buttonStyle="solid">
+          <Radio.Button value="public">Public</Radio.Button>
+          <Radio.Button value="invite">Invite only</Radio.Button>
+        </Radio.Group>
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="allowSpectators" label="Allow spectators" valuePropName="checked">
+        <Switch />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="voiceChat" label="Voice chat" valuePropName="checked">
+        <Switch />
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item name="startMode" label="Battle launch mode">
+        <Radio.Group optionType="button" buttonStyle="solid">
+          <Radio.Button value="manual">Manual start</Radio.Button>
+          <Radio.Button value="scheduled">Scheduled start</Radio.Button>
+        </Radio.Group>
+      </Form.Item>
+    </Col>
+    <Col {...fieldColProps}>
+      <Form.Item shouldUpdate noStyle>
+        {() => {
+          const mode = form.getFieldValue("startMode") as StartMode;
+          return (
+            <Form.Item
+              name="scheduledStartAt"
+              label="Scheduled start time"
+              rules={
+                mode === "scheduled"
+                  ? [
+                      {
+                        required: true,
+                        message: "Select a start time for the scheduled launch.",
+                      },
+                    ]
+                  : []
+              }
+            >
+              <DatePicker showTime style={{ width: "100%" }} disabled={mode !== "scheduled"} allowClear />
+            </Form.Item>
+          );
+        }}
+      </Form.Item>
+    </Col>
+  </Row>
+);

--- a/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/FormActions.tsx
+++ b/apps/app-ui/src/components/GetStarted/HostBattleForm/sections/FormActions.tsx
@@ -1,0 +1,21 @@
+import { Button, Form, Space } from "antd";
+import type { FC } from "react";
+
+interface FormActionsProps {
+  onReset: () => void;
+  submitButtonLabel: string;
+  submitButtonLoading: boolean;
+}
+
+export const FormActions: FC<FormActionsProps> = ({ onReset, submitButtonLabel, submitButtonLoading }) => (
+  <Form.Item shouldUpdate style={{ marginTop: 32 }}>
+    {() => (
+      <Space style={{ width: "100%", justifyContent: "flex-end" }}>
+        <Button onClick={onReset}>Reset</Button>
+        <Button type="primary" htmlType="submit" loading={submitButtonLoading}>
+          {submitButtonLabel}
+        </Button>
+      </Space>
+    )}
+  </Form.Item>
+);

--- a/apps/app-ui/src/features/hostBattle/hostBattleSlice.ts
+++ b/apps/app-ui/src/features/hostBattle/hostBattleSlice.ts
@@ -1,0 +1,219 @@
+import { createAsyncThunk, createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { BattleRecord } from "@rc/api-client";
+import { battleApi } from "../../services/api";
+import type { RootState } from "../../store/store";
+import type { HostBattleFormValues } from "./types";
+import {
+  buildBattlePayload,
+  createErrorMessage,
+  extractBattle,
+  extractBattles,
+  isConfigurableStatus,
+} from "./utils";
+
+export interface HostBattleState {
+  battles: BattleRecord[];
+  loading: boolean;
+  error: string | null;
+  isCreating: boolean;
+  isUpdating: boolean;
+  startingBattleId: string | null;
+  selectedBattleId: string | null;
+  isDrawerOpen: boolean;
+  showAdvancedOptions: boolean;
+  drawerAdvancedOptions: boolean;
+}
+
+const initialState: HostBattleState = {
+  battles: [],
+  loading: false,
+  error: null,
+  isCreating: false,
+  isUpdating: false,
+  startingBattleId: null,
+  selectedBattleId: null,
+  isDrawerOpen: false,
+  showAdvancedOptions: false,
+  drawerAdvancedOptions: false,
+};
+
+export const fetchBattles = createAsyncThunk<BattleRecord[], void, { rejectValue: string }>(
+  "hostBattle/fetchBattles",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await battleApi.listBattles();
+      return extractBattles(response);
+    } catch (error) {
+      return rejectWithValue(createErrorMessage(error, "Unable to load battles."));
+    }
+  },
+);
+
+export const createBattle = createAsyncThunk<BattleRecord, HostBattleFormValues, { rejectValue: string }>(
+  "hostBattle/createBattle",
+  async (values, { rejectWithValue }) => {
+    try {
+      const { create } = buildBattlePayload(values);
+      const response = await battleApi.createBattle(create);
+      const createdBattle = extractBattle(response);
+
+      if (!createdBattle) {
+        throw new Error("Battle creation response did not include the created battle.");
+      }
+
+      return createdBattle;
+    } catch (error) {
+      return rejectWithValue(createErrorMessage(error, "Failed to create battle."));
+    }
+  },
+);
+
+export const updateBattle = createAsyncThunk<
+  BattleRecord,
+  { battleId: string; values: HostBattleFormValues },
+  { rejectValue: string; state: RootState }
+>("hostBattle/updateBattle", async ({ battleId, values }, { rejectWithValue, getState }) => {
+  try {
+    const { update } = buildBattlePayload(values);
+    const response = await battleApi.updateBattle(battleId, update);
+    const updatedBattle = extractBattle(response);
+
+    if (updatedBattle) {
+      return updatedBattle;
+    }
+
+    const existing = getState().hostBattle.battles.find((battle) => battle.id === battleId);
+    if (!existing) {
+      throw new Error("Battle not found after update.");
+    }
+
+    return existing;
+  } catch (error) {
+    return rejectWithValue(createErrorMessage(error, "Failed to update battle."));
+  }
+});
+
+export const startBattle = createAsyncThunk<BattleRecord, string, { rejectValue: string; state: RootState }>(
+  "hostBattle/startBattle",
+  async (battleId, { rejectWithValue, getState }) => {
+    try {
+      const response = await battleApi.startBattle(battleId);
+      const startedBattle = extractBattle(response);
+
+      if (startedBattle) {
+        return startedBattle;
+      }
+
+      const existing = getState().hostBattle.battles.find((battle) => battle.id === battleId);
+      if (!existing) {
+        throw new Error("Battle not found after start.");
+      }
+
+      return existing;
+    } catch (error) {
+      return rejectWithValue(createErrorMessage(error, "Failed to start battle."));
+    }
+  },
+);
+
+const replaceBattle = (battles: BattleRecord[], next: BattleRecord) =>
+  battles.map((battle) => (battle.id === next.id ? next : battle));
+
+const upsertBattle = (battles: BattleRecord[], next: BattleRecord) => {
+  const hasBattle = battles.some((battle) => battle.id === next.id);
+  return hasBattle ? replaceBattle(battles, next) : [next, ...battles];
+};
+
+const hostBattleSlice = createSlice({
+  name: "hostBattle",
+  initialState,
+  reducers: {
+    setShowAdvancedOptions(state, action: PayloadAction<boolean>) {
+      state.showAdvancedOptions = action.payload;
+    },
+    setDrawerAdvancedOptions(state, action: PayloadAction<boolean>) {
+      state.drawerAdvancedOptions = action.payload;
+    },
+    openDrawer(state, action: PayloadAction<string>) {
+      state.selectedBattleId = action.payload;
+      state.isDrawerOpen = true;
+      state.drawerAdvancedOptions = false;
+    },
+    closeDrawer(state) {
+      state.isDrawerOpen = false;
+      state.selectedBattleId = null;
+      state.drawerAdvancedOptions = false;
+    },
+    clearError(state) {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchBattles.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchBattles.fulfilled, (state, action) => {
+        state.loading = false;
+        state.battles = action.payload;
+      })
+      .addCase(fetchBattles.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? action.error.message ?? "Unable to load battles.";
+      })
+      .addCase(createBattle.pending, (state) => {
+        state.isCreating = true;
+        state.error = null;
+      })
+      .addCase(createBattle.fulfilled, (state, action) => {
+        state.isCreating = false;
+        state.battles = upsertBattle(state.battles, action.payload);
+      })
+      .addCase(createBattle.rejected, (state, action) => {
+        state.isCreating = false;
+        state.error = action.payload ?? action.error.message ?? "Failed to create battle.";
+      })
+      .addCase(updateBattle.pending, (state) => {
+        state.isUpdating = true;
+        state.error = null;
+      })
+      .addCase(updateBattle.fulfilled, (state, action) => {
+        state.isUpdating = false;
+        state.battles = replaceBattle(state.battles, action.payload);
+      })
+      .addCase(updateBattle.rejected, (state, action) => {
+        state.isUpdating = false;
+        state.error = action.payload ?? action.error.message ?? "Failed to update battle.";
+      })
+      .addCase(startBattle.pending, (state, action) => {
+        state.startingBattleId = action.meta.arg;
+        state.error = null;
+      })
+      .addCase(startBattle.fulfilled, (state, action) => {
+        state.startingBattleId = null;
+        state.battles = replaceBattle(state.battles, action.payload);
+
+        if (state.selectedBattleId === action.payload.id && !isConfigurableStatus(action.payload.status)) {
+          state.isDrawerOpen = false;
+          state.selectedBattleId = null;
+          state.drawerAdvancedOptions = false;
+        }
+      })
+      .addCase(startBattle.rejected, (state, action) => {
+        state.startingBattleId = null;
+        state.error = action.payload ?? action.error.message ?? "Failed to start battle.";
+      });
+  },
+});
+
+export const hostBattleReducer = hostBattleSlice.reducer;
+export const {
+  setShowAdvancedOptions,
+  setDrawerAdvancedOptions,
+  openDrawer,
+  closeDrawer,
+  clearError,
+} = hostBattleSlice.actions;
+
+export type { HostBattleState };

--- a/apps/app-ui/src/features/hostBattle/selectors.ts
+++ b/apps/app-ui/src/features/hostBattle/selectors.ts
@@ -1,0 +1,42 @@
+import { createSelector } from "@reduxjs/toolkit";
+import type { RootState } from "../../store/store";
+import type { HostBattleState } from "./hostBattleSlice";
+
+export const selectHostBattleState = (state: RootState): HostBattleState => state.hostBattle;
+
+export const selectBattles = createSelector(selectHostBattleState, (state) => state.battles);
+
+export const selectHostBattleLoading = createSelector(selectHostBattleState, (state) => state.loading);
+
+export const selectShowAdvancedOptions = createSelector(
+  selectHostBattleState,
+  (state) => state.showAdvancedOptions,
+);
+
+export const selectDrawerAdvancedOptions = createSelector(
+  selectHostBattleState,
+  (state) => state.drawerAdvancedOptions,
+);
+
+export const selectDrawerOpen = createSelector(selectHostBattleState, (state) => state.isDrawerOpen);
+
+export const selectSelectedBattleId = createSelector(
+  selectHostBattleState,
+  (state) => state.selectedBattleId,
+);
+
+export const selectSelectedBattle = createSelector(
+  [selectBattles, selectSelectedBattleId],
+  (battles, selectedId) => battles.find((battle) => battle.id === selectedId) ?? null,
+);
+
+export const selectCreatePending = createSelector(selectHostBattleState, (state) => state.isCreating);
+
+export const selectUpdatePending = createSelector(selectHostBattleState, (state) => state.isUpdating);
+
+export const selectStartingBattleId = createSelector(
+  selectHostBattleState,
+  (state) => state.startingBattleId,
+);
+
+export const selectHostBattleError = createSelector(selectHostBattleState, (state) => state.error);

--- a/apps/app-ui/src/features/hostBattle/types.ts
+++ b/apps/app-ui/src/features/hostBattle/types.ts
@@ -1,0 +1,32 @@
+import type { Dayjs } from "dayjs";
+
+export type PrivacySetting = "public" | "invite";
+
+export type StartMode = "manual" | "scheduled";
+
+export interface HostBattleFormValues {
+  battleName: string;
+  shortDescription?: string;
+  gameMode?: string;
+  difficulty?: string;
+  maxPlayers?: number;
+  privacy: PrivacySetting;
+  allowSpectators: boolean;
+  voiceChat: boolean;
+  startMode: StartMode;
+  scheduledStartAt?: Dayjs | null;
+  turnTimeLimit?: number;
+  totalDuration?: number;
+  scoringRules?: string;
+  tieBreakPreference?: string;
+  powerUps?: string[];
+  teamBalancing: boolean;
+  ratingFloor?: number;
+  ratingCeiling?: number;
+  moderatorRoles?: string[];
+  preloadedResources?: string;
+  rematchDefaults: boolean;
+  joinQueueSize?: number;
+  password?: string;
+  linkExpiry?: string;
+}

--- a/apps/app-ui/src/features/hostBattle/utils.ts
+++ b/apps/app-ui/src/features/hostBattle/utils.ts
@@ -1,0 +1,185 @@
+import type {
+  BattleRecord,
+  BattleStatus,
+  CreateBattleRequestPayload,
+  UpdateBattleRequestPayload,
+} from "@rc/api-client";
+import dayjs from "dayjs";
+import type { HostBattleFormValues, StartMode } from "./types";
+
+export const configurableStatuses: BattleStatus[] = ["draft", "configuring", "ready", "scheduled"];
+
+export const statusMeta: Record<BattleStatus, { label: string; color: string }> = {
+  draft: { label: "Draft", color: "default" },
+  configuring: { label: "Configuring", color: "gold" },
+  ready: { label: "Ready", color: "green" },
+  scheduled: { label: "Scheduled", color: "blue" },
+  active: { label: "Active", color: "purple" },
+  completed: { label: "Completed", color: "default" },
+  cancelled: { label: "Cancelled", color: "red" },
+};
+
+export const formatDateTime = (value?: string | null) =>
+  value ? dayjs(value).format("MMM D, YYYY h:mm A") : "—";
+
+export const createErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
+export const extractBattles = (response: unknown): BattleRecord[] => {
+  const candidate = (response as { battles?: unknown }).battles;
+  return Array.isArray(candidate) ? (candidate as BattleRecord[]) : [];
+};
+
+export const extractBattle = (response: unknown): BattleRecord | undefined => {
+  const candidate = (response as { battle?: unknown }).battle;
+  if (candidate && typeof candidate === "object") {
+    return candidate as BattleRecord;
+  }
+  return undefined;
+};
+
+export const isConfigurableStatus = (status: BattleStatus) => configurableStatuses.includes(status);
+
+export const baseFormDefaults: Partial<HostBattleFormValues> = {
+  privacy: "public",
+  allowSpectators: true,
+  voiceChat: false,
+  startMode: "manual",
+  teamBalancing: true,
+  rematchDefaults: false,
+};
+
+const advancedFieldKeys: (keyof HostBattleFormValues)[] = [
+  "turnTimeLimit",
+  "totalDuration",
+  "scoringRules",
+  "tieBreakPreference",
+  "powerUps",
+  "ratingFloor",
+  "ratingCeiling",
+  "moderatorRoles",
+  "preloadedResources",
+  "rematchDefaults",
+  "joinQueueSize",
+  "password",
+  "linkExpiry",
+];
+
+export const shouldDisplayAdvanced = (values: Partial<HostBattleFormValues>) =>
+  advancedFieldKeys.some((key) => {
+    const value = values[key];
+
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+
+    if (typeof value === "number") {
+      return value !== undefined && value !== null;
+    }
+
+    if (typeof value === "boolean") {
+      return value === true;
+    }
+
+    return value !== undefined && value !== null && value !== "";
+  });
+
+export const buildBattlePayload = (
+  values: HostBattleFormValues,
+): {
+  create: CreateBattleRequestPayload;
+  update: UpdateBattleRequestPayload;
+  configuration: Record<string, unknown>;
+} => {
+  const startMode = (values.startMode ?? "manual") as StartMode;
+  const sanitizedName = values.battleName.trim();
+  const shortDescription = values.shortDescription?.trim() ?? "";
+  const scheduledStartAt =
+    startMode === "scheduled"
+      ? values.scheduledStartAt
+        ? values.scheduledStartAt.toISOString()
+        : null
+      : null;
+
+  const configurationInput = {
+    ...values,
+    battleName: sanitizedName,
+    shortDescription: shortDescription || undefined,
+    startMode,
+    scheduledStartAt,
+  };
+
+  const configuration = JSON.parse(JSON.stringify(configurationInput)) as Record<string, unknown>;
+
+  if (!shortDescription) {
+    delete configuration.shortDescription;
+  }
+
+  if (startMode !== "scheduled") {
+    configuration.scheduledStartAt = null;
+  }
+
+  const createPayload: CreateBattleRequestPayload = {
+    name: sanitizedName,
+    shortDescription: shortDescription ? shortDescription : null,
+    configuration,
+    startMode,
+    scheduledStartAt,
+  };
+
+  const updatePayload: UpdateBattleRequestPayload = {
+    name: sanitizedName,
+    shortDescription: shortDescription ? shortDescription : null,
+    configuration,
+    startMode,
+    scheduledStartAt,
+  };
+
+  return { create: createPayload, update: updatePayload, configuration };
+};
+
+export const extractFormValuesFromBattle = (
+  battle: BattleRecord,
+): Partial<HostBattleFormValues> => {
+  const configuration = (battle.configuration ?? {}) as Record<string, unknown>;
+  const storedStartMode =
+    typeof configuration.startMode === "string" ? (configuration.startMode as StartMode) : undefined;
+  const startMode: StartMode = storedStartMode ?? (battle.autoStart ? "scheduled" : "manual");
+
+  const scheduledSource =
+    battle.scheduledStartAt ??
+    (typeof configuration.scheduledStartAt === "string"
+      ? (configuration.scheduledStartAt as string)
+      : null);
+
+  const merged: Partial<HostBattleFormValues> = {
+    ...baseFormDefaults,
+    ...(configuration as Partial<HostBattleFormValues>),
+    battleName: battle.name,
+    shortDescription:
+      battle.shortDescription ??
+      (typeof configuration.shortDescription === "string"
+        ? (configuration.shortDescription as string)
+        : undefined),
+    startMode,
+    scheduledStartAt: scheduledSource ? dayjs(scheduledSource) : null,
+  };
+
+  if (typeof merged.allowSpectators !== "boolean") {
+    merged.allowSpectators = true;
+  }
+
+  if (typeof merged.voiceChat !== "boolean") {
+    merged.voiceChat = false;
+  }
+
+  if (typeof merged.teamBalancing !== "boolean") {
+    merged.teamBalancing = true;
+  }
+
+  if (typeof merged.rematchDefaults !== "boolean") {
+    merged.rematchDefaults = false;
+  }
+
+  return merged;
+};

--- a/apps/app-ui/src/pages/host-battle/HostBattlePage.tsx
+++ b/apps/app-ui/src/pages/host-battle/HostBattlePage.tsx
@@ -1,0 +1,208 @@
+import { Layout, message, Form } from "antd";
+import type { FC } from "react";
+import { useCallback, useEffect } from "react";
+import type { BattleRecord } from "@rc/api-client";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import {
+  closeDrawer,
+  createBattle,
+  fetchBattles,
+  openDrawer,
+  setDrawerAdvancedOptions,
+  setShowAdvancedOptions,
+  startBattle,
+  updateBattle,
+} from "../../features/hostBattle/hostBattleSlice";
+import {
+  selectBattles,
+  selectCreatePending,
+  selectDrawerAdvancedOptions,
+  selectDrawerOpen,
+  selectHostBattleLoading,
+  selectSelectedBattle,
+  selectShowAdvancedOptions,
+  selectStartingBattleId,
+  selectUpdatePending,
+} from "../../features/hostBattle/selectors";
+import {
+  extractFormValuesFromBattle,
+  isConfigurableStatus,
+  shouldDisplayAdvanced,
+} from "../../features/hostBattle/utils";
+import type { HostBattleFormValues } from "../../features/hostBattle/types";
+import { useHostBattleVisualConfig } from "./hooks/useHostBattleVisualConfig";
+import { BattleHero } from "./components/BattleHero";
+import { BattleSummaryCard } from "./components/BattleSummaryCard";
+import { BattleFormPanel } from "./components/BattleFormPanel";
+import { BattleListPanel } from "./components/BattleListPanel";
+import { BattleDrawer } from "./components/BattleDrawer";
+
+const { Content } = Layout;
+
+export const HostBattlePage: FC = () => {
+  const dispatch = useAppDispatch();
+  const battles = useAppSelector(selectBattles);
+  const loadingBattles = useAppSelector(selectHostBattleLoading);
+  const showAdvanced = useAppSelector(selectShowAdvancedOptions);
+  const drawerAdvanced = useAppSelector(selectDrawerAdvancedOptions);
+  const isDrawerOpen = useAppSelector(selectDrawerOpen);
+  const selectedBattle = useAppSelector(selectSelectedBattle);
+  const isCreating = useAppSelector(selectCreatePending);
+  const isUpdating = useAppSelector(selectUpdatePending);
+  const startingBattleId = useAppSelector(selectStartingBattleId);
+  const [form] = Form.useForm<HostBattleFormValues>();
+  const [drawerForm] = Form.useForm<HostBattleFormValues>();
+  const visual = useHostBattleVisualConfig();
+
+  useEffect(() => {
+    void dispatch(fetchBattles())
+      .unwrap()
+      .catch((error) => {
+        const messageText = typeof error === "string" ? error : "Unable to load battles.";
+        message.error(messageText);
+      });
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!selectedBattle) {
+      drawerForm.resetFields();
+      return;
+    }
+
+    const values = extractFormValuesFromBattle(selectedBattle);
+    drawerForm.setFieldsValue(values as Partial<HostBattleFormValues>);
+    dispatch(setDrawerAdvancedOptions(shouldDisplayAdvanced(values)));
+  }, [dispatch, drawerForm, selectedBattle]);
+
+  const handleToggleAdvanced = useCallback(
+    (checked: boolean) => {
+      dispatch(setShowAdvancedOptions(checked));
+    },
+    [dispatch],
+  );
+
+  const handleDrawerToggleAdvanced = useCallback(
+    (checked: boolean) => {
+      dispatch(setDrawerAdvancedOptions(checked));
+    },
+    [dispatch],
+  );
+
+  const handleCreateBattle = useCallback(
+    async (values: HostBattleFormValues) => {
+      try {
+        const battle = await dispatch(createBattle(values)).unwrap();
+        message.success(`Battle "${battle.name}" saved`);
+        form.resetFields();
+        dispatch(setShowAdvancedOptions(false));
+      } catch (error) {
+        const messageText = typeof error === "string" ? error : "Failed to create battle.";
+        message.error(messageText);
+      }
+    },
+    [dispatch, form],
+  );
+
+  const handleDrawerSubmit = useCallback(
+    async (values: HostBattleFormValues) => {
+      if (!selectedBattle) {
+        return;
+      }
+
+      try {
+        const battle = await dispatch(updateBattle({ battleId: selectedBattle.id, values })).unwrap();
+        message.success(`Battle "${battle.name}" updated`);
+
+        if (!isConfigurableStatus(battle.status)) {
+          dispatch(closeDrawer());
+          return;
+        }
+
+        const nextValues = extractFormValuesFromBattle(battle);
+        drawerForm.setFieldsValue(nextValues as Partial<HostBattleFormValues>);
+        dispatch(setDrawerAdvancedOptions(shouldDisplayAdvanced(nextValues)));
+      } catch (error) {
+        const messageText = typeof error === "string" ? error : "Failed to update battle.";
+        message.error(messageText);
+      }
+    },
+    [dispatch, drawerForm, selectedBattle],
+  );
+
+  const handleDrawerClose = useCallback(() => {
+    dispatch(closeDrawer());
+    drawerForm.resetFields();
+  }, [dispatch, drawerForm]);
+
+  const handleDrawerReset = useCallback(() => {
+    if (!selectedBattle) {
+      drawerForm.resetFields();
+      dispatch(setDrawerAdvancedOptions(false));
+      return;
+    }
+
+    const values = extractFormValuesFromBattle(selectedBattle);
+    drawerForm.setFieldsValue(values as Partial<HostBattleFormValues>);
+    dispatch(setDrawerAdvancedOptions(shouldDisplayAdvanced(values)));
+  }, [dispatch, drawerForm, selectedBattle]);
+
+  const handleConfigureBattle = useCallback(
+    (battle: BattleRecord) => {
+      dispatch(openDrawer(battle.id));
+    },
+    [dispatch],
+  );
+
+  const handleStartBattle = useCallback(
+    async (battle: BattleRecord) => {
+      try {
+        const updatedBattle = await dispatch(startBattle(battle.id)).unwrap();
+        message.success(`Battle "${updatedBattle.name}" launched`);
+      } catch (error) {
+        const messageText = typeof error === "string" ? error : "Failed to start battle.";
+        message.error(messageText);
+      }
+    },
+    [dispatch],
+  );
+
+  return (
+    <Content style={visual.styles.contentStyle}>
+      <div style={visual.styles.backgroundLayerStyle} />
+      <div style={visual.styles.innerContainerStyle}>
+        <BattleHero visual={visual} />
+        <div style={visual.styles.gridStyle}>
+          <BattleSummaryCard visual={visual} />
+          <BattleFormPanel
+            visual={visual}
+            form={form}
+            showAdvanced={showAdvanced}
+            onToggleAdvanced={handleToggleAdvanced}
+            onSubmit={handleCreateBattle}
+            submitButtonLoading={isCreating}
+          />
+        </div>
+        <BattleListPanel
+          visual={visual}
+          battles={battles}
+          loading={loadingBattles}
+          startingBattleId={startingBattleId}
+          onConfigure={handleConfigureBattle}
+          onStartBattle={handleStartBattle}
+        />
+      </div>
+      <BattleDrawer
+        visual={visual}
+        open={isDrawerOpen}
+        title={selectedBattle ? `Configure "${selectedBattle.name}"` : "Configure battle"}
+        form={drawerForm}
+        showAdvanced={drawerAdvanced}
+        onToggleAdvanced={handleDrawerToggleAdvanced}
+        onSubmit={handleDrawerSubmit}
+        onClose={handleDrawerClose}
+        onReset={handleDrawerReset}
+        submitButtonLoading={isUpdating}
+      />
+    </Content>
+  );
+};

--- a/apps/app-ui/src/pages/host-battle/components/BattleDrawer.tsx
+++ b/apps/app-ui/src/pages/host-battle/components/BattleDrawer.tsx
@@ -1,0 +1,49 @@
+import { ConfigProvider, Drawer } from "antd";
+import type { FormInstance } from "antd";
+import type { FC } from "react";
+import { HostBattleForm } from "../../../components/GetStarted/HostBattleForm";
+import type { HostBattleFormValues } from "../../../features/hostBattle/types";
+import type { HostBattleVisualConfig } from "../hooks/useHostBattleVisualConfig";
+
+interface BattleDrawerProps {
+  visual: HostBattleVisualConfig;
+  open: boolean;
+  title: string;
+  form: FormInstance<HostBattleFormValues>;
+  showAdvanced: boolean;
+  onToggleAdvanced: (checked: boolean) => void;
+  onSubmit: (values: HostBattleFormValues) => void;
+  onClose: () => void;
+  onReset: () => void;
+  submitButtonLoading: boolean;
+}
+
+export const BattleDrawer: FC<BattleDrawerProps> = ({
+  visual,
+  open,
+  title,
+  form,
+  showAdvanced,
+  onToggleAdvanced,
+  onSubmit,
+  onClose,
+  onReset,
+  submitButtonLoading,
+}) => (
+  <Drawer title={title} open={open} onClose={onClose} width={640} destroyOnClose={false} bodyStyle={{ padding: 0 }}>
+    <ConfigProvider theme={visual.styles.formTheme}>
+      <div className="host-battle-panel" style={{ ...visual.styles.formPanelStyle, border: "none", boxShadow: "none" }}>
+        <style>{visual.styles.formEnhancementStyles}</style>
+        <HostBattleForm
+          form={form}
+          showAdvanced={showAdvanced}
+          onToggleAdvanced={onToggleAdvanced}
+          onSubmit={onSubmit}
+          submitButtonLabel="Save changes"
+          submitButtonLoading={submitButtonLoading}
+          onReset={onReset}
+        />
+      </div>
+    </ConfigProvider>
+  </Drawer>
+);

--- a/apps/app-ui/src/pages/host-battle/components/BattleFormPanel.tsx
+++ b/apps/app-ui/src/pages/host-battle/components/BattleFormPanel.tsx
@@ -1,0 +1,37 @@
+import { ConfigProvider } from "antd";
+import type { FormInstance } from "antd";
+import type { FC } from "react";
+import { HostBattleForm } from "../../../components/GetStarted/HostBattleForm";
+import type { HostBattleFormValues } from "../../../features/hostBattle/types";
+import type { HostBattleVisualConfig } from "../hooks/useHostBattleVisualConfig";
+
+interface BattleFormPanelProps {
+  visual: HostBattleVisualConfig;
+  form: FormInstance<HostBattleFormValues>;
+  showAdvanced: boolean;
+  onToggleAdvanced: (checked: boolean) => void;
+  onSubmit: (values: HostBattleFormValues) => void;
+  submitButtonLoading: boolean;
+}
+
+export const BattleFormPanel: FC<BattleFormPanelProps> = ({
+  visual,
+  form,
+  showAdvanced,
+  onToggleAdvanced,
+  onSubmit,
+  submitButtonLoading,
+}) => (
+  <ConfigProvider theme={visual.styles.formTheme}>
+    <div className="host-battle-panel" style={visual.styles.formPanelStyle}>
+      <style>{visual.styles.formEnhancementStyles}</style>
+      <HostBattleForm
+        form={form}
+        showAdvanced={showAdvanced}
+        onToggleAdvanced={onToggleAdvanced}
+        onSubmit={onSubmit}
+        submitButtonLoading={submitButtonLoading}
+      />
+    </div>
+  </ConfigProvider>
+);

--- a/apps/app-ui/src/pages/host-battle/components/BattleHero.tsx
+++ b/apps/app-ui/src/pages/host-battle/components/BattleHero.tsx
@@ -1,0 +1,26 @@
+import { Typography } from "antd";
+import type { FC } from "react";
+import { Link } from "react-router-dom";
+import type { HostBattleVisualConfig } from "../hooks/useHostBattleVisualConfig";
+
+const { Title, Paragraph, Text } = Typography;
+
+interface BattleHeroProps {
+  visual: HostBattleVisualConfig;
+}
+
+export const BattleHero: FC<BattleHeroProps> = ({ visual }) => (
+  <div style={visual.styles.headerStyle}>
+    <Title level={2} style={{ margin: 0, color: visual.palette.headingColor }}>
+      Host your own battle
+    </Title>
+    <Paragraph style={{ margin: 0, color: visual.palette.bodyTextColor }}>
+      Configure the rules, invite your competitors, and tailor the experience before you go live. Everything updates
+      instantly so you can share the lobby the moment it feels ready.
+    </Paragraph>
+    <Text style={{ color: visual.palette.linkHintColor }}>
+      Prefer to join an existing competition? <Link to="/" style={{ color: visual.accentColor }}>Return to the lobby</Link>
+      to paste an invite link or code.
+    </Text>
+  </div>
+);

--- a/apps/app-ui/src/pages/host-battle/components/BattleListPanel.tsx
+++ b/apps/app-ui/src/pages/host-battle/components/BattleListPanel.tsx
@@ -1,0 +1,133 @@
+import { Button, ConfigProvider, Empty, Space, Table, Tag, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import type { FC } from "react";
+import { useMemo } from "react";
+import type { BattleRecord } from "@rc/api-client";
+import type { HostBattleVisualConfig } from "../hooks/useHostBattleVisualConfig";
+import { formatDateTime, isConfigurableStatus, statusMeta } from "../../../features/hostBattle/utils";
+
+const { Title, Paragraph, Text } = Typography;
+
+interface BattleListPanelProps {
+  visual: HostBattleVisualConfig;
+  battles: BattleRecord[];
+  loading: boolean;
+  startingBattleId: string | null;
+  onConfigure: (battle: BattleRecord) => void;
+  onStartBattle: (battle: BattleRecord) => void;
+}
+
+export const BattleListPanel: FC<BattleListPanelProps> = ({
+  visual,
+  battles,
+  loading,
+  startingBattleId,
+  onConfigure,
+  onStartBattle,
+}) => {
+  const columns = useMemo<ColumnsType<BattleRecord>>(
+    () => [
+      {
+        title: "Battle",
+        dataIndex: "name",
+        key: "name",
+        render: (_, record) => (
+          <Space direction="vertical" size={2}>
+            <Text strong style={{ color: visual.palette.headingColor }}>
+              {record.name}
+            </Text>
+            {record.shortDescription ? (
+              <Text type="secondary" style={{ color: visual.palette.paragraphMutedColor }}>
+                {record.shortDescription}
+              </Text>
+            ) : null}
+          </Space>
+        ),
+      },
+      {
+        title: "Mode",
+        dataIndex: ["configuration", "gameMode"],
+        key: "mode",
+        render: (_, record) => {
+          const config = (record.configuration ?? {}) as { gameMode?: string; difficulty?: string };
+          const parts = [config.gameMode, config.difficulty].filter(Boolean);
+          return parts.length ? parts.join(" · ") : "—";
+        },
+      },
+      {
+        title: "Players",
+        dataIndex: ["configuration", "maxPlayers"],
+        key: "players",
+        render: (_, record) => {
+          const config = (record.configuration ?? {}) as { maxPlayers?: number };
+          return config.maxPlayers ?? "—";
+        },
+      },
+      {
+        title: "Status",
+        dataIndex: "status",
+        key: "status",
+        render: (value: BattleRecord["status"]) => {
+          const meta = statusMeta[value];
+          return <Tag color={meta.color}>{meta.label}</Tag>;
+        },
+      },
+      {
+        title: "Scheduled",
+        dataIndex: "scheduledStartAt",
+        key: "scheduledStartAt",
+        render: (value: string | null | undefined, record) => {
+          const config = (record.configuration ?? {}) as { scheduledStartAt?: string | null };
+          return formatDateTime(value ?? config.scheduledStartAt);
+        },
+      },
+      {
+        title: "Actions",
+        key: "actions",
+        render: (_, record) => {
+          const canStart = isConfigurableStatus(record.status) && !record.autoStart;
+          return (
+            <Space size="small">
+              <Button type="link" onClick={() => onConfigure(record)} disabled={!isConfigurableStatus(record.status)}>
+                Configure
+              </Button>
+              <Button
+                type="link"
+                onClick={() => onStartBattle(record)}
+                disabled={!canStart}
+                loading={startingBattleId === record.id}
+              >
+                Start now
+              </Button>
+            </Space>
+          );
+        },
+      },
+    ],
+    [onConfigure, onStartBattle, startingBattleId, visual.palette.headingColor, visual.palette.paragraphMutedColor],
+  );
+
+  return (
+    <ConfigProvider theme={visual.styles.formTheme}>
+      <div style={visual.styles.tablePanelStyle}>
+        <Title level={4} style={{ margin: 0, color: visual.palette.headingColor }}>
+          Battle control center
+        </Title>
+        <Paragraph style={{ margin: 0, color: visual.palette.bodyTextColor }}>
+          Monitor upcoming battles, tweak configurations, and launch when the timing is right. Scheduled battles will
+          auto-launch, while manual battles stay parked here until you start them.
+        </Paragraph>
+        <Table
+          columns={columns}
+          dataSource={battles}
+          rowKey="id"
+          loading={loading}
+          pagination={false}
+          size="middle"
+          locale={{ emptyText: <Empty description="No battles configured yet" /> }}
+          style={{ background: "transparent" }}
+        />
+      </div>
+    </ConfigProvider>
+  );
+};

--- a/apps/app-ui/src/pages/host-battle/components/BattleSummaryCard.tsx
+++ b/apps/app-ui/src/pages/host-battle/components/BattleSummaryCard.tsx
@@ -1,0 +1,42 @@
+import { Divider, Space, Tag, Typography, theme } from "antd";
+import type { FC } from "react";
+import type { HostBattleVisualConfig } from "../hooks/useHostBattleVisualConfig";
+
+const { Title, Paragraph, Text } = Typography;
+
+interface BattleSummaryCardProps {
+  visual: HostBattleVisualConfig;
+}
+
+export const BattleSummaryCard: FC<BattleSummaryCardProps> = ({ visual }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <div style={visual.styles.summaryCardStyle}>
+      <Title level={4} style={{ margin: 0, color: visual.palette.headingColor }}>
+        Battle blueprint
+      </Title>
+      <Paragraph style={{ margin: 0, color: visual.palette.bodyTextColor }}>
+        Outline your format, scheduling, and moderation in one pass. You can revisit this setup any time before the battle
+        starts.
+      </Paragraph>
+      <Space size={[token.marginSM, token.marginSM]} wrap>
+        <Tag style={visual.styles.tagStyle}>Real-time control</Tag>
+        <Tag style={visual.styles.tagStyle}>Private or public</Tag>
+        <Tag style={visual.styles.tagStyle}>Power-up pools</Tag>
+      </Space>
+      <Divider style={{ margin: `${token.marginMD}px 0`, borderColor: visual.palette.dividerColor }} />
+      <Paragraph strong style={{ margin: 0, color: visual.palette.headingColor }}>
+        Setup checklist
+      </Paragraph>
+      <ul style={visual.styles.highlightListStyle}>
+        <li>Pick battle modes, difficulty, and player limits that match your format.</li>
+        <li>Lock down privacy, queue sizing, and moderation so teams join smoothly.</li>
+        <li>Enable advanced scoring, power-ups, and resources when you want extra spectacle.</li>
+      </ul>
+      <Paragraph style={{ margin: 0, color: visual.palette.paragraphMutedColor }}>
+        Need inspiration? <Text style={{ color: visual.accentColor }}>Community templates</Text> are dropping soon.
+      </Paragraph>
+    </div>
+  );
+};

--- a/apps/app-ui/src/pages/host-battle/hooks/useHostBattleVisualConfig.ts
+++ b/apps/app-ui/src/pages/host-battle/hooks/useHostBattleVisualConfig.ts
@@ -1,0 +1,438 @@
+import { useMemo } from "react";
+import type { CSSProperties } from "react";
+import type { ConfigProviderProps } from "antd";
+import { theme } from "antd";
+import { useThemeMode } from "../../../providers/theme-mode-context";
+
+export interface HostBattlePalette {
+  backgroundGradients: string[];
+  summaryBackground: string;
+  summaryBorderColor: string;
+  summaryShadow: string;
+  highlightListColor: string;
+  panelBackground: string;
+  panelBorderColor: string;
+  panelShadow: string;
+  tagBorderColor: string;
+  tagBackground: string;
+  tagTextColor: string;
+  controlTextColor: string;
+  controlBackground: string;
+  controlBorderColor: string;
+  controlBorderHoverColor: string;
+  controlOutlineColor: string;
+  controlPlaceholderColor: string;
+  controlArrowColor: string;
+  checkboxTextColor: string;
+  radioInactiveBackground: string;
+  radioInactiveTextColor: string;
+  radioShadow: string;
+  switchBackground: string;
+  switchCheckedBackground: string;
+  primaryButtonShadow: string;
+  dropdownBackground: string;
+  dropdownBorderColor: string;
+  dropdownShadow: string;
+  dropdownTextColor: string;
+  dropdownActiveBackground: string;
+  dropdownActiveTextColor: string;
+  dropdownSelectedBackground: string;
+  dropdownSelectedTextColor: string;
+  headingColor: string;
+  bodyTextColor: string;
+  paragraphMutedColor: string;
+  linkHintColor: string;
+  dividerColor: string;
+  labelColor: string;
+  optionalLabelColor: string;
+}
+
+export interface HostBattleVisualConfig {
+  palette: HostBattlePalette;
+  accentColor: string;
+  styles: {
+    contentStyle: CSSProperties;
+    backgroundLayerStyle: CSSProperties;
+    innerContainerStyle: CSSProperties;
+    headerStyle: CSSProperties;
+    gridStyle: CSSProperties;
+    summaryCardStyle: CSSProperties;
+    highlightListStyle: CSSProperties;
+    formPanelStyle: CSSProperties;
+    tablePanelStyle: CSSProperties;
+    tagStyle: CSSProperties;
+    formTheme: ConfigProviderProps["theme"];
+    formEnhancementStyles: string;
+  };
+}
+
+export const useHostBattleVisualConfig = (): HostBattleVisualConfig => {
+  const { token } = theme.useToken();
+  const { mode } = useThemeMode();
+  const accentColor = token.colorWarning;
+  const isDark = mode === "dark";
+
+  const palette = useMemo<HostBattlePalette>(
+    () =>
+      isDark
+        ? {
+            backgroundGradients: [
+              "radial-gradient(900px circle at 10% 20%, rgba(250, 219, 20, 0.16), transparent 60%)",
+              "radial-gradient(720px circle at 85% 15%, rgba(83, 86, 255, 0.18), transparent 65%)",
+              "linear-gradient(160deg, rgba(8, 13, 34, 0.95), rgba(5, 8, 20, 0.98))",
+            ],
+            summaryBackground: "rgba(12, 18, 40, 0.78)",
+            summaryBorderColor: `${accentColor}29`,
+            summaryShadow: "0 30px 70px rgba(4, 8, 20, 0.4)",
+            highlightListColor: "rgba(240, 245, 255, 0.82)",
+            panelBackground: "rgba(6, 12, 32, 0.92)",
+            panelBorderColor: `${accentColor}33`,
+            panelShadow: "0 30px 80px rgba(3, 6, 18, 0.55)",
+            tagBorderColor: `${accentColor}66`,
+            tagBackground: `${accentColor}22`,
+            tagTextColor: "rgba(240, 245, 255, 0.9)",
+            controlTextColor: "rgba(240, 245, 255, 0.95)",
+            controlBackground: "rgba(15, 22, 46, 0.65)",
+            controlBorderColor: `${accentColor}33`,
+            controlBorderHoverColor: `${accentColor}AA`,
+            controlOutlineColor: `${accentColor}AA`,
+            controlPlaceholderColor: "rgba(240, 245, 255, 0.45)",
+            controlArrowColor: "rgba(240, 245, 255, 0.75)",
+            checkboxTextColor: "rgba(240, 245, 255, 0.85)",
+            radioInactiveBackground: "rgba(15, 22, 46, 0.6)",
+            radioInactiveTextColor: "rgba(240, 245, 255, 0.85)",
+            radioShadow: "0 12px 32px rgba(250, 219, 20, 0.32)",
+            switchBackground: `${accentColor}33`,
+            switchCheckedBackground: accentColor,
+            primaryButtonShadow: "0 18px 40px rgba(250, 219, 20, 0.25)",
+            dropdownBackground: "rgba(8, 13, 34, 0.96)",
+            dropdownBorderColor: `${accentColor}33`,
+            dropdownShadow: "0 24px 80px rgba(3, 6, 18, 0.6)",
+            dropdownTextColor: "rgba(240, 245, 255, 0.88)",
+            dropdownActiveBackground: `${accentColor}26`,
+            dropdownActiveTextColor: "rgba(240, 245, 255, 0.95)",
+            dropdownSelectedBackground: accentColor,
+            dropdownSelectedTextColor: "#050814",
+            headingColor: token.colorWhite,
+            bodyTextColor: "rgba(240, 245, 255, 0.78)",
+            paragraphMutedColor: "rgba(240, 245, 255, 0.68)",
+            linkHintColor: "rgba(240, 245, 255, 0.65)",
+            dividerColor: `${accentColor}33`,
+            labelColor: "rgba(240, 245, 255, 0.92)",
+            optionalLabelColor: "rgba(240, 245, 255, 0.6)",
+          }
+        : {
+            backgroundGradients: [
+              "radial-gradient(900px circle at 12% 20%, rgba(250, 219, 20, 0.32), transparent 60%)",
+              "radial-gradient(720px circle at 82% 18%, rgba(106, 114, 255, 0.2), transparent 65%)",
+              "linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(244, 248, 255, 0.98))",
+            ],
+            summaryBackground: "rgba(255, 255, 255, 0.92)",
+            summaryBorderColor: "rgba(15, 23, 42, 0.08)",
+            summaryShadow: "0 28px 56px rgba(15, 23, 42, 0.12)",
+            highlightListColor: "rgba(36, 52, 93, 0.82)",
+            panelBackground: "rgba(255, 255, 255, 0.96)",
+            panelBorderColor: "rgba(15, 23, 42, 0.08)",
+            panelShadow: "0 32px 60px rgba(15, 23, 42, 0.14)",
+            tagBorderColor: "rgba(250, 219, 20, 0.3)",
+            tagBackground: "rgba(250, 219, 20, 0.12)",
+            tagTextColor: "rgba(23, 30, 54, 0.9)",
+            controlTextColor: "rgba(23, 30, 54, 0.92)",
+            controlBackground: "rgba(250, 252, 255, 0.95)",
+            controlBorderColor: "rgba(15, 23, 42, 0.12)",
+            controlBorderHoverColor: `${accentColor}80`,
+            controlOutlineColor: `${accentColor}80`,
+            controlPlaceholderColor: "rgba(71, 85, 134, 0.55)",
+            controlArrowColor: "rgba(36, 52, 93, 0.55)",
+            checkboxTextColor: "rgba(36, 52, 93, 0.82)",
+            radioInactiveBackground: "rgba(245, 248, 255, 0.9)",
+            radioInactiveTextColor: "rgba(36, 52, 93, 0.85)",
+            radioShadow: "0 12px 30px rgba(250, 219, 20, 0.2)",
+            switchBackground: `${accentColor}33`,
+            switchCheckedBackground: accentColor,
+            primaryButtonShadow: "0 18px 32px rgba(250, 219, 20, 0.2)",
+            dropdownBackground: "rgba(255, 255, 255, 0.98)",
+            dropdownBorderColor: "rgba(15, 23, 42, 0.08)",
+            dropdownShadow: "0 24px 60px rgba(15, 23, 42, 0.18)",
+            dropdownTextColor: "rgba(36, 52, 93, 0.88)",
+            dropdownActiveBackground: `${accentColor}26`,
+            dropdownActiveTextColor: "rgba(36, 52, 93, 0.88)",
+            dropdownSelectedBackground: accentColor,
+            dropdownSelectedTextColor: "#050814",
+            headingColor: token.colorTextHeading,
+            bodyTextColor: "rgba(36, 52, 93, 0.85)",
+            paragraphMutedColor: "rgba(57, 72, 112, 0.72)",
+            linkHintColor: "rgba(60, 75, 120, 0.7)",
+            dividerColor: "rgba(15, 23, 42, 0.08)",
+            labelColor: "rgba(36, 52, 93, 0.9)",
+            optionalLabelColor: "rgba(71, 85, 134, 0.6)",
+          },
+    [accentColor, isDark, token.colorTextHeading, token.colorWhite],
+  );
+
+  const styles = useMemo(() => {
+    const contentStyle: CSSProperties = {
+      padding: "clamp(48px, 6vw, 96px) clamp(24px, 6vw, 64px)",
+      position: "relative",
+      overflow: "hidden",
+      display: "flex",
+      justifyContent: "center",
+    };
+
+    const backgroundLayerStyle: CSSProperties = {
+      position: "absolute",
+      inset: 0,
+      background: palette.backgroundGradients.join(","),
+      pointerEvents: "none",
+    };
+
+    const innerContainerStyle: CSSProperties = {
+      position: "relative",
+      zIndex: 1,
+      width: "min(1120px, 100%)",
+      display: "flex",
+      flexDirection: "column",
+      gap: token.marginXL,
+    };
+
+    const headerStyle: CSSProperties = {
+      maxWidth: "720px",
+      display: "flex",
+      flexDirection: "column",
+      gap: token.marginMD,
+    };
+
+    const gridStyle: CSSProperties = {
+      display: "grid",
+      gap: token.marginXL,
+      gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+      alignItems: "flex-start",
+      alignContent: "flex-start",
+    };
+
+    const summaryCardStyle: CSSProperties = {
+      background: palette.summaryBackground,
+      border: `1px solid ${palette.summaryBorderColor}`,
+      boxShadow: palette.summaryShadow,
+      backdropFilter: "blur(18px)",
+      borderRadius: 24,
+      padding: "clamp(24px, 4vw, 36px)",
+      display: "flex",
+      flexDirection: "column",
+      gap: token.marginMD,
+    };
+
+    const highlightListStyle: CSSProperties = {
+      margin: 0,
+      paddingLeft: "1.2rem",
+      color: palette.highlightListColor,
+      display: "flex",
+      flexDirection: "column",
+      gap: 12,
+    };
+
+    const formPanelStyle: CSSProperties = {
+      background: palette.panelBackground,
+      border: `1px solid ${palette.panelBorderColor}`,
+      borderRadius: 24,
+      padding: "clamp(24px, 4vw, 32px)",
+      boxShadow: palette.panelShadow,
+      display: "flex",
+      flexDirection: "column",
+      gap: token.marginLG,
+    };
+
+    const tablePanelStyle: CSSProperties = {
+      background: palette.panelBackground,
+      border: `1px solid ${palette.panelBorderColor}`,
+      borderRadius: 24,
+      padding: "clamp(24px, 4vw, 32px)",
+      boxShadow: palette.panelShadow,
+      display: "flex",
+      flexDirection: "column",
+      gap: token.marginMD,
+    };
+
+    const tagStyle: CSSProperties = {
+      borderColor: palette.tagBorderColor,
+      background: palette.tagBackground,
+      color: palette.tagTextColor,
+      fontWeight: 600,
+      letterSpacing: "0.01em",
+    };
+
+    const formTheme: ConfigProviderProps["theme"] = {
+      token: {
+        colorText: palette.controlTextColor,
+        colorBgElevated: palette.panelBackground,
+        colorBorder: palette.controlBorderColor,
+        colorPrimary: accentColor,
+        colorPrimaryHover: palette.controlBorderHoverColor,
+        colorPrimaryActive: accentColor,
+        controlOutline: palette.controlOutlineColor,
+        colorBgContainer: palette.controlBackground,
+      },
+      components: {
+        Input: {
+          colorBgContainer: palette.controlBackground,
+          colorBorder: palette.controlBorderColor,
+          colorTextPlaceholder: palette.controlPlaceholderColor,
+        },
+        Select: {
+          colorBgContainer: palette.controlBackground,
+          colorBorder: palette.controlBorderColor,
+          colorText: palette.controlTextColor,
+        },
+        InputNumber: {
+          colorBgContainer: palette.controlBackground,
+          colorBorder: palette.controlBorderColor,
+          colorText: palette.controlTextColor,
+        },
+        DatePicker: {
+          colorBgContainer: palette.controlBackground,
+          colorBorder: palette.controlBorderColor,
+          colorText: palette.controlTextColor,
+        },
+        Radio: {
+          buttonColor: palette.radioInactiveBackground,
+          buttonSolidCheckedColor: accentColor,
+          colorText: palette.radioInactiveTextColor,
+        },
+        Switch: {
+          colorPrimary: accentColor,
+        },
+        Checkbox: {
+          colorPrimary: accentColor,
+        },
+        Form: {
+          labelColor: palette.labelColor,
+        },
+      },
+    };
+
+    const formEnhancementStyles = `
+      .host-battle-panel .ant-form-item-label > label {
+        color: ${palette.labelColor} !important;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+      .host-battle-panel .ant-form-item-label > label .ant-form-item-optional,
+      .host-battle-panel .ant-form-item-optional {
+        color: ${palette.optionalLabelColor} !important;
+      }
+      .host-battle-panel .ant-input,
+      .host-battle-panel .ant-input-affix-wrapper,
+      .host-battle-panel .ant-select-selector,
+      .host-battle-panel .ant-select-selection-item,
+      .host-battle-panel .ant-select-selection-placeholder,
+      .host-battle-panel .ant-input-number,
+      .host-battle-panel .ant-input-number-input {
+        background: ${palette.controlBackground} !important;
+        border-color: ${palette.controlBorderColor} !important;
+        color: ${palette.controlTextColor} !important;
+      }
+      .host-battle-panel .ant-input:hover,
+      .host-battle-panel .ant-input-affix-wrapper:hover,
+      .host-battle-panel .ant-select-selector:hover,
+      .host-battle-panel .ant-input-number:hover {
+        border-color: ${palette.controlBorderHoverColor} !important;
+      }
+      .host-battle-panel .ant-input::placeholder,
+      .host-battle-panel .ant-input-number-input::placeholder {
+        color: ${palette.controlPlaceholderColor} !important;
+      }
+      .host-battle-panel .ant-select-selection-placeholder {
+        color: ${palette.controlPlaceholderColor} !important;
+      }
+      .host-battle-panel .ant-select-arrow,
+      .host-battle-panel .ant-picker-suffix {
+        color: ${palette.controlArrowColor} !important;
+      }
+      .host-battle-panel .ant-radio-button-wrapper {
+        background: ${palette.radioInactiveBackground} !important;
+        color: ${palette.radioInactiveTextColor} !important;
+        border-color: ${palette.controlBorderColor} !important;
+      }
+      .host-battle-panel .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-checked):hover {
+        border-color: ${palette.controlBorderHoverColor} !important;
+        color: ${accentColor} !important;
+      }
+      .host-battle-panel .ant-radio-button-wrapper-checked {
+        background: ${accentColor} !important;
+        color: #050814 !important;
+        border-color: ${accentColor} !important;
+        box-shadow: ${palette.radioShadow};
+      }
+      .host-battle-panel .ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled)::before {
+        background-color: ${accentColor} !important;
+      }
+      .host-battle-panel .ant-radio-inner,
+      .host-battle-panel .ant-checkbox-inner {
+        border-color: ${palette.controlBorderColor} !important;
+      }
+      .host-battle-panel .ant-radio-checked .ant-radio-inner {
+        border-color: ${accentColor} !important;
+      }
+      .host-battle-panel .ant-radio-checked .ant-radio-inner::after {
+        background-color: ${accentColor} !important;
+      }
+      .host-battle-panel .ant-checkbox-wrapper,
+      .host-battle-panel .ant-checkbox + span {
+        color: ${palette.checkboxTextColor} !important;
+      }
+      .host-battle-panel .ant-checkbox-checked .ant-checkbox-inner {
+        background-color: ${accentColor} !important;
+        border-color: ${accentColor} !important;
+      }
+      .host-battle-panel .ant-switch {
+        background: ${palette.switchBackground} !important;
+      }
+      .host-battle-panel .ant-switch.ant-switch-checked {
+        background: ${palette.switchCheckedBackground} !important;
+      }
+      .host-battle-panel .ant-form-item-required::before {
+        color: ${accentColor} !important;
+      }
+      .host-battle-panel .ant-btn-primary {
+        box-shadow: ${palette.primaryButtonShadow};
+      }
+      .host-battle-select-dropdown {
+        background: ${palette.dropdownBackground} !important;
+        border: 1px solid ${palette.dropdownBorderColor} !important;
+        box-shadow: ${palette.dropdownShadow} !important;
+      }
+      .host-battle-select-dropdown .ant-select-item {
+        color: ${palette.dropdownTextColor} !important;
+      }
+      .host-battle-select-dropdown .ant-select-item-option-active {
+        background: ${palette.dropdownActiveBackground} !important;
+        color: ${palette.dropdownActiveTextColor} !important;
+      }
+      .host-battle-select-dropdown .ant-select-item-option-selected {
+        background: ${palette.dropdownSelectedBackground} !important;
+        color: ${palette.dropdownSelectedTextColor} !important;
+      }
+    `;
+
+    return {
+      contentStyle,
+      backgroundLayerStyle,
+      innerContainerStyle,
+      headerStyle,
+      gridStyle,
+      summaryCardStyle,
+      highlightListStyle,
+      formPanelStyle,
+      tablePanelStyle,
+      tagStyle,
+      formTheme,
+      formEnhancementStyles,
+    };
+  }, [accentColor, palette, token.marginLG, token.marginMD, token.marginXL]);
+
+  return {
+    palette,
+    accentColor,
+    styles,
+  };
+};

--- a/apps/app-ui/src/pages/host-battle/index.ts
+++ b/apps/app-ui/src/pages/host-battle/index.ts
@@ -1,0 +1,1 @@
+export { HostBattlePage } from "./HostBattlePage";

--- a/apps/app-ui/src/store/store.ts
+++ b/apps/app-ui/src/store/store.ts
@@ -2,12 +2,14 @@ import { configureStore } from "@reduxjs/toolkit";
 import { arenaReducer } from "../features/arena/arenaSlice";
 import { authReducer } from "../features/auth/authSlice";
 import { environmentReducer } from "../features/environment/environmentSlice";
+import { hostBattleReducer } from "../features/hostBattle/hostBattleSlice";
 
 export const store = configureStore({
   reducer: {
     arena: arenaReducer,
     auth: authReducer,
     environment: environmentReducer,
+    hostBattle: hostBattleReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- introduce a dedicated `hostBattle` redux slice with async thunks for listing, creating, updating, and starting battles
- refactor the host battle page into modular components with a shared visual hook and updated redux-backed flows
- split the large host battle form into reusable sections with shared options while keeping advanced controls toggled via redux

## Testing
- pnpm --filter app-ui lint

------
https://chatgpt.com/codex/tasks/task_e_68e0f404d930832583acfba2cf6e4a2c